### PR TITLE
Performance improvements

### DIFF
--- a/cmd/cmgrd/main.go
+++ b/cmd/cmgrd/main.go
@@ -96,6 +96,9 @@ Relevant environment variables:
       does not exist on the host running the Docker daemon, Docker will silently
       ignore this value and instead bind to the loopback address
 
+  CMGR_PRUNE_AGE - the maximum age for on-demand challenge instances; old
+      instances are automatically pruned from the database (defaults to '1h');
+      set to '0' to disable automatic pruning.
   CMGR_DB_WAL - controls whether SQLite WAL journaling mode is enabled;
       on by default for improved throughput under high concurrency;
       creates <db>-wal and <db>-shm sidecar files; do NOT use on network-mounted

--- a/cmgr/api.go
+++ b/cmgr/api.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"sync/atomic"
 	"time"
 
 	"github.com/picoCTF/cmgr/cmgr/dockerfiles"
@@ -596,7 +595,7 @@ func (m *Manager) checkPrune() {
 	}
 
 	now := time.Now().UnixNano()
-	last := atomic.LoadInt64(&m.lastPruneUnix)
+	last := m.lastPruneUnix.Load()
 
 	// Fast path: interval hasn't elapsed — no lock needed.
 	if time.Duration(now-last) < m.pruneInterval {
@@ -604,7 +603,7 @@ func (m *Manager) checkPrune() {
 	}
 
 	// CAS to claim the prune slot; only one goroutine wins per interval.
-	if !atomic.CompareAndSwapInt64(&m.lastPruneUnix, last, now) {
+	if !m.lastPruneUnix.CompareAndSwap(last, now) {
 		return
 	}
 

--- a/cmgr/api.go
+++ b/cmgr/api.go
@@ -517,19 +517,9 @@ func (m *Manager) GetSchemaState(name string) ([]*ChallengeMetadata, error) {
 			return nil, err
 		}
 
-		iids, err := m.getBuildInstances(build.Id)
+		build.Instances, err = m.lookupBuildInstances(build.Id)
 		if err != nil {
 			return nil, err
-		}
-
-		build.Instances = make([]*InstanceMetadata, len(iids))
-		for i, iid := range iids {
-			instance, err := m.lookupInstanceMetadata(iid)
-			if err != nil {
-				return nil, err
-			}
-
-			build.Instances[i] = instance
 		}
 
 		if challenge != nil && challenge.Id != build.Challenge {

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -289,7 +289,7 @@ func (m *Manager) usedPortBitset() ([]uint64, error) {
 	}
 
 	numPorts := m.portHigh - m.portLow + 1
-	bitset := make([]uint64, (numPorts/64)+1)
+	bitset := make([]uint64, (numPorts+63)/64)
 
 	rows, err := m.db.Query("SELECT port FROM portAssignments WHERE port BETWEEN ? AND ?", m.portLow, m.portHigh)
 	if err != nil {

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -352,20 +352,10 @@ func (m *Manager) dumpState() ([]*ChallengeMetadata, error) {
 				return nil, err
 			}
 
-			bMeta.Instances = []*InstanceMetadata{}
-			err = m.db.Select(&bMeta.Instances, "SELECT id FROM instances WHERE build=?", bMeta.Id)
+			bMeta.Instances, err = m.lookupBuildInstances(bMeta.Id)
 			if err != nil {
 				m.log.errorf("failed to select instances for '%s/%d': %s", challenge.Id, bMeta.Id, err)
 				return nil, err
-			}
-
-			for k, instance := range bMeta.Instances {
-				iMeta, err := m.lookupInstanceMetadata(instance.Id)
-				if err != nil {
-					return nil, err
-				}
-
-				bMeta.Instances[k] = iMeta
 			}
 			meta.Builds[j] = bMeta
 		}

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -191,7 +191,9 @@ func (m *Manager) initDatabase() error {
 
 	// _busy_timeout=50 gives SQLite up to 50ms to retry acquiring a lock before
 	// returning SQLITE_BUSY; avoids instant failures under concurrent access.
-	dsn := dbPath + "?_fk=true&_journal_mode=WAL&_busy_timeout=50"
+	// _synchronous=NORMAL is safe in WAL mode: WAL provides crash consistency,
+	// so only the very last committed transaction risks loss on catastrophic failure.
+	dsn := dbPath + "?_fk=true&_journal_mode=WAL&_busy_timeout=50&_synchronous=NORMAL"
 	if walEnv, ok := os.LookupEnv(DB_WAL_ENV); ok && (walEnv == "false" || walEnv == "0" || walEnv == "off") {
 		dsn = dbPath + "?_fk=true&_busy_timeout=50"
 	}

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -169,7 +169,16 @@ const schemaQuery string = `
 		cgroupparent TEXT NOT NULL,
 		FOREIGN KEY (challenge) REFERENCES challenges (id)
 			ON UPDATE CASCADE ON DELETE CASCADE
-	);`
+	);
+
+	CREATE INDEX IF NOT EXISTS instanceBuildIndex ON instances(build);
+	CREATE INDEX IF NOT EXISTS portAssignmentInstanceIndex ON portAssignments(instance);
+	CREATE INDEX IF NOT EXISTS portAssignmentPortIndex ON portAssignments(port);
+	CREATE INDEX IF NOT EXISTS containerInstanceIndex ON containers(instance);
+	CREATE INDEX IF NOT EXISTS imageBuildIndex ON images(build);
+	CREATE INDEX IF NOT EXISTS imagePortImageIndex ON imagePorts(image);
+	CREATE INDEX IF NOT EXISTS lookupDataBuildIndex ON lookupData(build);
+`
 
 // Connects to the desired database (creating it if it does not exist) and then
 // ensures that the necessary tables and indexes exist and that the sqlite

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -283,6 +283,36 @@ func (m *Manager) usedPortSet() (map[int]struct{}, error) {
 	return portSet, err
 }
 
+func (m *Manager) usedPortBitset() ([]uint64, error) {
+	if m.portLow == 0 {
+		return nil, nil
+	}
+
+	numPorts := m.portHigh - m.portLow + 1
+	bitset := make([]uint64, (numPorts/64)+1)
+
+	rows, err := m.db.Query("SELECT port FROM portAssignments WHERE port BETWEEN ? AND ?", m.portLow, m.portHigh)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var port int
+		if err := rows.Scan(&port); err != nil {
+			return nil, err
+		}
+		p := port - m.portLow
+		bitset[p/64] |= (1 << (uint(p) % 64))
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return bitset, nil
+}
+
 func (m *Manager) safeToRefresh(new *ChallengeMetadata) bool {
 	old, err := m.lookupChallengeMetadata(new.Id)
 	if err != nil {

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -191,8 +191,9 @@ func (m *Manager) initDatabase() error {
 
 	// _busy_timeout=50 gives SQLite up to 50ms to retry acquiring a lock before
 	// returning SQLITE_BUSY; avoids instant failures under concurrent access.
-	// _synchronous=NORMAL is safe in WAL mode: WAL provides crash consistency,
-	// so only the very last committed transaction risks loss on catastrophic failure.
+	// In WAL mode, _synchronous=NORMAL preserves database consistency but can lose
+	// the most recent committed transactions on a crash or power loss (potentially
+	// more than one), in exchange for better performance than FULL.
 	dsn := dbPath + "?_fk=true&_journal_mode=WAL&_busy_timeout=50&_synchronous=NORMAL"
 	if walEnv, ok := os.LookupEnv(DB_WAL_ENV); ok && (walEnv == "false" || walEnv == "0" || walEnv == "off") {
 		dsn = dbPath + "?_fk=true&_busy_timeout=50"

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -189,9 +189,11 @@ func (m *Manager) initDatabase() error {
 		dbPath = "cmgr.db"
 	}
 
-	dsn := dbPath + "?_fk=true&_journal_mode=WAL"
+	// _busy_timeout=50 gives SQLite up to 50ms to retry acquiring a lock before
+	// returning SQLITE_BUSY; avoids instant failures under concurrent access.
+	dsn := dbPath + "?_fk=true&_journal_mode=WAL&_busy_timeout=50"
 	if walEnv, ok := os.LookupEnv(DB_WAL_ENV); ok && (walEnv == "false" || walEnv == "0" || walEnv == "off") {
-		dsn = dbPath + "?_fk=true"
+		dsn = dbPath + "?_fk=true&_busy_timeout=50"
 	}
 
 	db, err := sqlx.Open("sqlite3", dsn)

--- a/cmgr/database_instances.go
+++ b/cmgr/database_instances.go
@@ -191,3 +191,65 @@ func (m *Manager) recordSolve(instance *InstanceMetadata) error {
 	}
 	return err
 }
+
+func (m *Manager) lookupBuildInstances(build BuildId) ([]*InstanceMetadata, error) {
+	var instances []*InstanceMetadata
+	err := m.db.Select(&instances, "SELECT * FROM instances WHERE build = ?", build)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(instances) == 0 {
+		return instances, nil
+	}
+
+	// Fetch all ports for these instances
+	ports := []struct {
+		Instance InstanceId `db:"instance"`
+		Name     string     `db:"name"`
+		Port     int        `db:"port"`
+	}{}
+	err = m.db.Select(&ports, "SELECT instance, name, port FROM portAssignments WHERE instance IN (SELECT id FROM instances WHERE build = ?)", build)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map ports to instances
+	portMap := make(map[InstanceId]map[string]int)
+	for _, p := range ports {
+		if _, ok := portMap[p.Instance]; !ok {
+			portMap[p.Instance] = make(map[string]int)
+		}
+		portMap[p.Instance][p.Name] = p.Port
+	}
+
+	// Fetch all containers for these instances
+	containers := []struct {
+		Instance InstanceId `db:"instance"`
+		Id       string     `db:"id"`
+	}{}
+	err = m.db.Select(&containers, "SELECT instance, id FROM containers WHERE instance IN (SELECT id FROM instances WHERE build = ?)", build)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map containers to instances
+	containerMap := make(map[InstanceId][]string)
+	for _, c := range containers {
+		containerMap[c.Instance] = append(containerMap[c.Instance], c.Id)
+	}
+
+	// Combine
+	for _, inst := range instances {
+		inst.Ports = portMap[inst.Id]
+		if inst.Ports == nil {
+			inst.Ports = make(map[string]int)
+		}
+		inst.Containers = containerMap[inst.Id]
+		if inst.Containers == nil {
+			inst.Containers = []string{}
+		}
+	}
+
+	return instances, nil
+}

--- a/cmgr/database_instances.go
+++ b/cmgr/database_instances.go
@@ -194,14 +194,9 @@ func (m *Manager) recordSolve(instance *InstanceMetadata) error {
 
 func (m *Manager) lookupBuildInstances(build BuildId) ([]*InstanceMetadata, error) {
 	var instances []*InstanceMetadata
-	err := m.db.Select(&instances, "SELECT * FROM instances WHERE build = ?", build)
-	if err != nil {
-		return nil, err
-	}
+	txn := m.db.MustBegin()
 
-	if len(instances) == 0 {
-		return instances, nil
-	}
+	err := txn.Select(&instances, "SELECT * FROM instances WHERE build = ?", build)
 
 	// Fetch all ports for these instances
 	ports := []struct {
@@ -209,7 +204,33 @@ func (m *Manager) lookupBuildInstances(build BuildId) ([]*InstanceMetadata, erro
 		Name     string     `db:"name"`
 		Port     int        `db:"port"`
 	}{}
-	err = m.db.Select(&ports, "SELECT instance, name, port FROM portAssignments WHERE instance IN (SELECT id FROM instances WHERE build = ?)", build)
+	if err == nil && len(instances) > 0 {
+		err = txn.Select(&ports, "SELECT instance, name, port FROM portAssignments WHERE instance IN (SELECT id FROM instances WHERE build = ?)", build)
+	}
+
+	// Fetch all containers for these instances
+	containers := []struct {
+		Instance InstanceId `db:"instance"`
+		Id       string     `db:"id"`
+	}{}
+	if err == nil && len(instances) > 0 {
+		err = txn.Select(&containers, "SELECT instance, id FROM containers WHERE instance IN (SELECT id FROM instances WHERE build = ?)", build)
+	}
+
+	if err == nil {
+		err = txn.Commit()
+		if err != nil {
+			m.log.errorf("failed to commit read-only transaction: %s", err)
+		}
+	} else {
+		m.log.errorf("read of database failed: %s", err)
+		closeErr := txn.Rollback()
+		if closeErr != nil {
+			m.log.errorf("rollback failed: %s", closeErr)
+			err = closeErr
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -221,16 +242,6 @@ func (m *Manager) lookupBuildInstances(build BuildId) ([]*InstanceMetadata, erro
 			portMap[p.Instance] = make(map[string]int)
 		}
 		portMap[p.Instance][p.Name] = p.Port
-	}
-
-	// Fetch all containers for these instances
-	containers := []struct {
-		Instance InstanceId `db:"instance"`
-		Id       string     `db:"id"`
-	}{}
-	err = m.db.Select(&containers, "SELECT instance, id FROM containers WHERE instance IN (SELECT id FROM instances WHERE build = ?)", build)
-	if err != nil {
-		return nil, err
 	}
 
 	// Map containers to instances

--- a/cmgr/database_instances.go
+++ b/cmgr/database_instances.go
@@ -194,9 +194,13 @@ func (m *Manager) recordSolve(instance *InstanceMetadata) error {
 
 func (m *Manager) lookupBuildInstances(build BuildId) ([]*InstanceMetadata, error) {
 	var instances []*InstanceMetadata
-	txn := m.db.MustBegin()
+	txn, err := m.db.Beginx()
+	if err != nil {
+		return nil, err
+	}
+	defer txn.Rollback() //nolint:errcheck
 
-	err := txn.Select(&instances, "SELECT * FROM instances WHERE build = ?", build)
+	err = txn.Select(&instances, "SELECT * FROM instances WHERE build = ?", build)
 
 	// Fetch all ports for these instances
 	ports := []struct {
@@ -205,7 +209,7 @@ func (m *Manager) lookupBuildInstances(build BuildId) ([]*InstanceMetadata, erro
 		Port     int        `db:"port"`
 	}{}
 	if err == nil && len(instances) > 0 {
-		err = txn.Select(&ports, "SELECT instance, name, port FROM portAssignments WHERE instance IN (SELECT id FROM instances WHERE build = ?)", build)
+		err = txn.Select(&ports, "SELECT p.instance, p.name, p.port FROM portAssignments p JOIN instances i ON p.instance = i.id WHERE i.build = ?", build)
 	}
 
 	// Fetch all containers for these instances
@@ -214,24 +218,16 @@ func (m *Manager) lookupBuildInstances(build BuildId) ([]*InstanceMetadata, erro
 		Id       string     `db:"id"`
 	}{}
 	if err == nil && len(instances) > 0 {
-		err = txn.Select(&containers, "SELECT instance, id FROM containers WHERE instance IN (SELECT id FROM instances WHERE build = ?)", build)
-	}
-
-	if err == nil {
-		err = txn.Commit()
-		if err != nil {
-			m.log.errorf("failed to commit read-only transaction: %s", err)
-		}
-	} else {
-		m.log.errorf("read of database failed: %s", err)
-		closeErr := txn.Rollback()
-		if closeErr != nil {
-			m.log.errorf("rollback failed: %s", closeErr)
-			err = closeErr
-		}
+		err = txn.Select(&containers, "SELECT c.instance, c.id FROM containers c JOIN instances i ON c.instance = i.id WHERE i.build = ?", build)
 	}
 
 	if err != nil {
+		m.log.errorf("read of database failed: %s", err)
+		return nil, err
+	}
+
+	if err = txn.Commit(); err != nil {
+		m.log.errorf("failed to commit read-only transaction: %s", err)
 		return nil, err
 	}
 

--- a/cmgr/database_operations_test.go
+++ b/cmgr/database_operations_test.go
@@ -1054,6 +1054,269 @@ func TestGetFreePortAllUsed(t *testing.T) {
 	}
 }
 
+// TestLookupBuildInstances verifies that lookupBuildInstances returns instances with
+// Ports and Containers correctly populated, and handles multiple instances per build.
+// It also confirms equivalence with the getBuildInstances()+lookupInstanceMetadata loop
+// it replaced.
+func TestLookupBuildInstances(t *testing.T) {
+	mgr := setupTestManager(t)
+	defer mgr.db.Close()
+
+	// Helper to set up a challenge and build
+	setupBuild := func(challengeId ChallengeId, schema string) *BuildMetadata {
+		t.Helper()
+		challenge := &ChallengeMetadata{
+			Id:            challengeId,
+			Name:          string(challengeId),
+			Namespace:     "test",
+			ChallengeType: "custom",
+			Description:   "lookup build instances test",
+			Hosts:         []HostInfo{{Name: "challenge", Target: ""}},
+			PortMap:       map[string]PortInfo{},
+			Tags:          []string{},
+			Attributes:    map[string]string{},
+			Path:          "/tmp/test/problem.md",
+			ChallengeOptions: ChallengeOptions{
+				Overrides: map[string]ContainerOptions{"": {}},
+			},
+		}
+		errs := mgr.addChallenges([]*ChallengeMetadata{challenge})
+		if len(errs) > 0 {
+			t.Fatalf("addChallenges failed: %v", errs)
+		}
+		build := &BuildMetadata{
+			Seed:          1,
+			Format:        "flag{%s}",
+			Challenge:     challengeId,
+			Schema:        schema,
+			InstanceCount: DYNAMIC_INSTANCES,
+		}
+		if err := mgr.openBuild(build); err != nil {
+			t.Fatalf("openBuild failed: %s", err)
+		}
+		build.Flag = "flag{test}"
+		build.Images = []Image{{Host: "challenge", Ports: []string{"80/tcp"}}}
+		build.LookupData = map[string]string{}
+		if err := mgr.finalizeBuild(build); err != nil {
+			t.Fatalf("finalizeBuild failed: %s", err)
+		}
+		return build
+	}
+
+	// Helper to open and finalize an instance with given ports and containers
+	addInstance := func(build *BuildMetadata, ports map[string]int, containers []string) *InstanceMetadata {
+		t.Helper()
+		inst := &InstanceMetadata{Build: build.Id}
+		if err := mgr.openInstance(inst); err != nil {
+			t.Fatalf("openInstance failed: %s", err)
+		}
+		inst.Ports = ports
+		inst.Containers = containers
+		if err := mgr.finalizeInstance(inst); err != nil {
+			t.Fatalf("finalizeInstance failed: %s", err)
+		}
+		return inst
+	}
+
+	t.Run("empty build returns no instances", func(t *testing.T) {
+		build := setupBuild("test/lbi-empty", "lbi-empty")
+		instances, err := mgr.lookupBuildInstances(build.Id)
+		if err != nil {
+			t.Fatalf("lookupBuildInstances failed: %s", err)
+		}
+		if len(instances) != 0 {
+			t.Errorf("expected 0 instances, got %d", len(instances))
+		}
+	})
+
+	t.Run("single instance with ports and containers", func(t *testing.T) {
+		build := setupBuild("test/lbi-single", "lbi-single")
+		inst := addInstance(build,
+			map[string]int{"http": 8080, "https": 8443},
+			[]string{"container-aaa", "container-bbb"},
+		)
+
+		instances, err := mgr.lookupBuildInstances(build.Id)
+		if err != nil {
+			t.Fatalf("lookupBuildInstances failed: %s", err)
+		}
+		if len(instances) != 1 {
+			t.Fatalf("expected 1 instance, got %d", len(instances))
+		}
+
+		got := instances[0]
+		if got.Id != inst.Id {
+			t.Errorf("expected instance ID %d, got %d", inst.Id, got.Id)
+		}
+		if got.Build != build.Id {
+			t.Errorf("expected build ID %d, got %d", build.Id, got.Build)
+		}
+		if got.Ports["http"] != 8080 {
+			t.Errorf("expected Ports[http]=8080, got %d", got.Ports["http"])
+		}
+		if got.Ports["https"] != 8443 {
+			t.Errorf("expected Ports[https]=8443, got %d", got.Ports["https"])
+		}
+		if len(got.Containers) != 2 {
+			t.Errorf("expected 2 containers, got %d: %v", len(got.Containers), got.Containers)
+		} else {
+			containerSet := make(map[string]bool)
+			for _, c := range got.Containers {
+				containerSet[c] = true
+			}
+			if !containerSet["container-aaa"] || !containerSet["container-bbb"] {
+				t.Errorf("expected containers [container-aaa, container-bbb], got %v", got.Containers)
+			}
+		}
+	})
+
+	t.Run("multiple instances each with distinct ports and containers", func(t *testing.T) {
+		build := setupBuild("test/lbi-multi", "lbi-multi")
+
+		inst1 := addInstance(build,
+			map[string]int{"http": 9001},
+			[]string{"c-alpha"},
+		)
+		inst2 := addInstance(build,
+			map[string]int{"http": 9002, "debug": 9003},
+			[]string{"c-beta", "c-gamma"},
+		)
+		inst3 := addInstance(build,
+			map[string]int{},
+			[]string{},
+		)
+
+		instances, err := mgr.lookupBuildInstances(build.Id)
+		if err != nil {
+			t.Fatalf("lookupBuildInstances failed: %s", err)
+		}
+		if len(instances) != 3 {
+			t.Fatalf("expected 3 instances, got %d", len(instances))
+		}
+
+		// Build a map by ID for order-independent checking
+		byID := make(map[InstanceId]*InstanceMetadata, len(instances))
+		for _, inst := range instances {
+			byID[inst.Id] = inst
+		}
+
+		// Instance 1
+		got1, ok := byID[inst1.Id]
+		if !ok {
+			t.Fatalf("instance %d not found in results", inst1.Id)
+		}
+		if got1.Ports["http"] != 9001 {
+			t.Errorf("inst1: expected Ports[http]=9001, got %d", got1.Ports["http"])
+		}
+		if len(got1.Containers) != 1 || got1.Containers[0] != "c-alpha" {
+			t.Errorf("inst1: unexpected containers: %v", got1.Containers)
+		}
+
+		// Instance 2
+		got2, ok := byID[inst2.Id]
+		if !ok {
+			t.Fatalf("instance %d not found in results", inst2.Id)
+		}
+		if got2.Ports["http"] != 9002 {
+			t.Errorf("inst2: expected Ports[http]=9002, got %d", got2.Ports["http"])
+		}
+		if got2.Ports["debug"] != 9003 {
+			t.Errorf("inst2: expected Ports[debug]=9003, got %d", got2.Ports["debug"])
+		}
+		if len(got2.Containers) != 2 {
+			t.Errorf("inst2: expected 2 containers, got %d: %v", len(got2.Containers), got2.Containers)
+		} else {
+			containerSet := make(map[string]bool)
+			for _, c := range got2.Containers {
+				containerSet[c] = true
+			}
+			if !containerSet["c-beta"] || !containerSet["c-gamma"] {
+				t.Errorf("inst2: expected containers [c-beta, c-gamma], got %v", got2.Containers)
+			}
+		}
+
+		// Instance 3 (no ports, no containers)
+		got3, ok := byID[inst3.Id]
+		if !ok {
+			t.Fatalf("instance %d not found in results", inst3.Id)
+		}
+		if len(got3.Ports) != 0 {
+			t.Errorf("inst3: expected empty ports, got %v", got3.Ports)
+		}
+		if len(got3.Containers) != 0 {
+			t.Errorf("inst3: expected empty containers, got %v", got3.Containers)
+		}
+	})
+
+	t.Run("equivalence with getBuildInstances+lookupInstanceMetadata loop", func(t *testing.T) {
+		build := setupBuild("test/lbi-equiv", "lbi-equiv")
+		addInstance(build, map[string]int{"svc": 7001}, []string{"c-one"})
+		addInstance(build, map[string]int{"svc": 7002}, []string{"c-two", "c-three"})
+
+		// New batch approach
+		batchInstances, err := mgr.lookupBuildInstances(build.Id)
+		if err != nil {
+			t.Fatalf("lookupBuildInstances failed: %s", err)
+		}
+
+		// Legacy loop approach: getBuildInstances + lookupInstanceMetadata per ID
+		ids, err := mgr.getBuildInstances(build.Id)
+		if err != nil {
+			t.Fatalf("getBuildInstances failed: %s", err)
+		}
+		loopInstances := make([]*InstanceMetadata, 0, len(ids))
+		for _, id := range ids {
+			meta, err := mgr.lookupInstanceMetadata(id)
+			if err != nil {
+				t.Fatalf("lookupInstanceMetadata(%d) failed: %s", id, err)
+			}
+			loopInstances = append(loopInstances, meta)
+		}
+
+		if len(batchInstances) != len(loopInstances) {
+			t.Fatalf("length mismatch: batch=%d loop=%d", len(batchInstances), len(loopInstances))
+		}
+
+		// Index batch results by ID
+		batchByID := make(map[InstanceId]*InstanceMetadata, len(batchInstances))
+		for _, inst := range batchInstances {
+			batchByID[inst.Id] = inst
+		}
+
+		for _, loopInst := range loopInstances {
+			batchInst, ok := batchByID[loopInst.Id]
+			if !ok {
+				t.Errorf("instance %d from loop not found in batch results", loopInst.Id)
+				continue
+			}
+			if batchInst.Build != loopInst.Build {
+				t.Errorf("instance %d: Build mismatch batch=%d loop=%d", loopInst.Id, batchInst.Build, loopInst.Build)
+			}
+			if len(batchInst.Ports) != len(loopInst.Ports) {
+				t.Errorf("instance %d: Ports length mismatch batch=%d loop=%d", loopInst.Id, len(batchInst.Ports), len(loopInst.Ports))
+			}
+			for name, port := range loopInst.Ports {
+				if batchInst.Ports[name] != port {
+					t.Errorf("instance %d: Ports[%s] mismatch batch=%d loop=%d", loopInst.Id, name, batchInst.Ports[name], port)
+				}
+			}
+			if len(batchInst.Containers) != len(loopInst.Containers) {
+				t.Errorf("instance %d: Containers length mismatch batch=%d loop=%d", loopInst.Id, len(batchInst.Containers), len(loopInst.Containers))
+			} else {
+				loopContainerSet := make(map[string]bool, len(loopInst.Containers))
+				for _, c := range loopInst.Containers {
+					loopContainerSet[c] = true
+				}
+				for _, c := range batchInst.Containers {
+					if !loopContainerSet[c] {
+						t.Errorf("instance %d: batch container %q not found in loop result %v", loopInst.Id, c, loopInst.Containers)
+					}
+				}
+			}
+		}
+	})
+}
+
 // setupTestManager creates a Manager with a temporary on-disk database file for testing
 func setupTestManager(t *testing.T) *Manager {
 	t.Helper()

--- a/cmgr/database_operations_test.go
+++ b/cmgr/database_operations_test.go
@@ -2,6 +2,7 @@ package cmgr
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -828,6 +829,228 @@ func TestDatabasePortOperations(t *testing.T) {
 	}
 	if len(portSet) != 0 {
 		t.Errorf("expected empty port set, got %v", portSet)
+	}
+}
+
+// setupPortAssignments is a helper that creates a challenge, build, and instance
+// with the given ports assigned in the database, and returns the manager.
+// portLow and portHigh configure the manager's port range for bitset tests.
+func setupPortAssignments(t *testing.T, portLow, portHigh int, ports map[string]int) *Manager {
+	t.Helper()
+	mgr := setupTestManager(t)
+	mgr.portLow = portLow
+	mgr.portHigh = portHigh
+
+	challenge := &ChallengeMetadata{
+		Id:            "test/port-assign-test",
+		Name:          "Port Assign Test",
+		Namespace:     "test",
+		ChallengeType: "custom",
+		Description:   "Testing port assignments",
+		Hosts:         []HostInfo{{Name: "challenge", Target: ""}},
+		PortMap:       map[string]PortInfo{},
+		Tags:          []string{},
+		Attributes:    map[string]string{},
+		Path:          "/tmp/test/problem.md",
+		ChallengeOptions: ChallengeOptions{
+			Overrides: map[string]ContainerOptions{
+				"": {},
+			},
+		},
+	}
+	errs := mgr.addChallenges([]*ChallengeMetadata{challenge})
+	if len(errs) > 0 {
+		t.Fatalf("addChallenges failed: %v", errs)
+	}
+
+	build := &BuildMetadata{
+		Seed:          1,
+		Format:        "flag{%s}",
+		Challenge:     "test/port-assign-test",
+		Schema:        "manual-test",
+		InstanceCount: DYNAMIC_INSTANCES,
+	}
+	if err := mgr.openBuild(build); err != nil {
+		t.Fatalf("openBuild failed: %s", err)
+	}
+	build.Flag = "flag{port_assign}"
+	build.Images = []Image{{Host: "challenge", Ports: []string{}}}
+	build.LookupData = map[string]string{}
+	if err := mgr.finalizeBuild(build); err != nil {
+		t.Fatalf("finalizeBuild failed: %s", err)
+	}
+
+	instance := &InstanceMetadata{
+		Build:      build.Id,
+		Ports:      map[string]int{},
+		Containers: []string{},
+	}
+	if err := mgr.openInstance(instance); err != nil {
+		t.Fatalf("openInstance failed: %s", err)
+	}
+	instance.Ports = ports
+	instance.Containers = []string{}
+	if err := mgr.finalizeInstance(instance); err != nil {
+		t.Fatalf("finalizeInstance failed: %s", err)
+	}
+
+	return mgr
+}
+
+// TestUsedPortBitset verifies that usedPortBitset returns a bitset that marks
+// exactly the ports recorded in portAssignments within [portLow, portHigh].
+func TestUsedPortBitset(t *testing.T) {
+	// Use a small range so we can reason about exact bit positions.
+	const portLow = 30000
+	const portHigh = 30063 // exactly 64 ports → one uint64 word
+
+	assignedPorts := map[string]int{
+		"http":  30000, // bit 0
+		"https": 30001, // bit 1
+		"ssh":   30063, // bit 63
+	}
+
+	mgr := setupPortAssignments(t, portLow, portHigh, assignedPorts)
+	defer mgr.db.Close()
+
+	bitset, err := mgr.usedPortBitset()
+	if err != nil {
+		t.Fatalf("usedPortBitset failed: %s", err)
+	}
+	if len(bitset) == 0 {
+		t.Fatal("expected non-empty bitset")
+	}
+
+	for name, port := range assignedPorts {
+		p := port - portLow
+		word := p / 64
+		bit := uint(p) % 64
+		if bitset[word]&(1<<bit) == 0 {
+			t.Errorf("port %d (%s) should be marked in bitset but is not", port, name)
+		}
+	}
+
+	// Verify that an unassigned port in the range is NOT marked.
+	unassigned := 30002
+	p := unassigned - portLow
+	word := p / 64
+	bit := uint(p) % 64
+	if bitset[word]&(1<<bit) != 0 {
+		t.Errorf("port %d should not be marked in bitset", unassigned)
+	}
+}
+
+// TestUsedPortBitsetNoRange verifies that usedPortBitset returns nil when no
+// port range is configured (portLow == 0).
+func TestUsedPortBitsetNoRange(t *testing.T) {
+	mgr := setupTestManager(t)
+	defer mgr.db.Close()
+	// portLow defaults to 0 from setupTestManager
+
+	bitset, err := mgr.usedPortBitset()
+	if err != nil {
+		t.Fatalf("usedPortBitset failed: %s", err)
+	}
+	if bitset != nil {
+		t.Errorf("expected nil bitset when portLow==0, got %v", bitset)
+	}
+}
+
+// TestGetFreePortNoRange verifies that getFreePort returns an empty string
+// (ephemeral port mode) when no port range is configured.
+func TestGetFreePortNoRange(t *testing.T) {
+	mgr := setupTestManager(t)
+	defer mgr.db.Close()
+	// portLow defaults to 0
+
+	port, err := mgr.getFreePort()
+	if err != nil {
+		t.Fatalf("getFreePort failed: %s", err)
+	}
+	if port != "" {
+		t.Errorf("expected empty string for ephemeral port mode, got %q", port)
+	}
+}
+
+// TestGetFreePortWithRange verifies that getFreePort returns a valid port
+// within [portLow, portHigh] when the range is configured and ports are free.
+func TestGetFreePortWithRange(t *testing.T) {
+	const portLow = 40000
+	const portHigh = 40010
+
+	mgr := setupTestManager(t)
+	defer mgr.db.Close()
+	mgr.portLow = portLow
+	mgr.portHigh = portHigh
+
+	portStr, err := mgr.getFreePort()
+	if err != nil {
+		t.Fatalf("getFreePort failed: %s", err)
+	}
+	if portStr == "" {
+		t.Fatal("expected a non-empty port string")
+	}
+
+	var port int
+	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
+		t.Fatalf("returned port is not a number: %q", portStr)
+	}
+	if port < portLow || port > portHigh {
+		t.Errorf("returned port %d is outside range [%d, %d]", port, portLow, portHigh)
+	}
+}
+
+// TestGetFreePortSkipsUsed verifies that getFreePort does not return a port
+// that is already recorded in portAssignments.
+func TestGetFreePortSkipsUsed(t *testing.T) {
+	const portLow = 50000
+	const portHigh = 50002 // only 3 ports: 50000, 50001, 50002
+
+	// Assign two of the three ports, leaving only 50002 free.
+	assignedPorts := map[string]int{
+		"svc1": 50000,
+		"svc2": 50001,
+	}
+
+	mgr := setupPortAssignments(t, portLow, portHigh, assignedPorts)
+	defer mgr.db.Close()
+
+	portStr, err := mgr.getFreePort()
+	if err != nil {
+		t.Fatalf("getFreePort failed: %s", err)
+	}
+
+	var port int
+	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
+		t.Fatalf("returned port is not a number: %q", portStr)
+	}
+	if port < portLow || port > portHigh {
+		t.Errorf("returned port %d is outside range [%d, %d]", port, portLow, portHigh)
+	}
+	for name, assigned := range assignedPorts {
+		if port == assigned {
+			t.Errorf("returned port %d (%s) is already assigned", port, name)
+		}
+	}
+}
+
+// TestGetFreePortAllUsed verifies that getFreePort returns an error when all
+// ports in the configured range are already assigned.
+func TestGetFreePortAllUsed(t *testing.T) {
+	const portLow = 60000
+	const portHigh = 60001 // only 2 ports
+
+	assignedPorts := map[string]int{
+		"svc1": 60000,
+		"svc2": 60001,
+	}
+
+	mgr := setupPortAssignments(t, portLow, portHigh, assignedPorts)
+	defer mgr.db.Close()
+
+	_, err := mgr.getFreePort()
+	if err == nil {
+		t.Error("expected an error when all ports are in use, got nil")
 	}
 }
 

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -117,9 +117,11 @@ func (m *Manager) getFreePort() (string, error) {
 
 	numPorts := m.portHigh - m.portLow + 1
 
-	// Get currently used ports...
-	ports, err := m.usedPortSet()
+	// Get currently used ports as a bitset for memory efficiency
+	bitset, err := m.usedPortBitset()
 	if err != nil {
+		// Fallback to ephemeral port if we can't get the bitset,
+		// though this shouldn't happen under normal operation.
 		return "", nil
 	}
 
@@ -128,7 +130,8 @@ func (m *Manager) getFreePort() (string, error) {
 
 	// Sweep through ports looking for a free one...
 	for i := 0; i < numPorts; i++ {
-		if _, used := ports[port]; !used {
+		p := port - m.portLow
+		if (bitset[p/64] & (1 << (uint(p) % 64))) == 0 {
 			return fmt.Sprint(port), nil
 		}
 

--- a/cmgr/prune_test.go
+++ b/cmgr/prune_test.go
@@ -1,7 +1,6 @@
 package cmgr
 
 import (
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -184,7 +183,7 @@ func TestCheckPruneSkipsWithinInterval(t *testing.T) {
 	backdateInstance(t, mgr, iid, 2*time.Hour)
 
 	// Record "now" as the last prune time so the interval hasn't elapsed.
-	atomic.StoreInt64(&mgr.lastPruneUnix, time.Now().UnixNano())
+	mgr.lastPruneUnix.Store(time.Now().UnixNano())
 
 	mgr.checkPrune()
 

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -48,7 +48,7 @@ type Manager struct {
 	authString           string
 	portLow              int
 	portHigh             int
-	lastPruneUnix        atomic.Int64 // Unix nanoseconds
+	lastPruneUnix        atomic.Int64 // atomic UnixNano timestamp used as CAS gate for prune interval
 	pruneInterval        time.Duration
 	pruneAge             time.Duration
 }

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -3,6 +3,7 @@ package cmgr
 import (
 	"context"
 	"math/rand"
+	"sync/atomic"
 	"time"
 
 	"github.com/docker/docker/client"
@@ -47,7 +48,7 @@ type Manager struct {
 	authString           string
 	portLow              int
 	portHigh             int
-	lastPruneUnix        int64 // Unix nanoseconds; accessed atomically
+	lastPruneUnix        atomic.Int64 // Unix nanoseconds
 	pruneInterval        time.Duration
 	pruneAge             time.Duration
 }


### PR DESCRIPTION
- Add db indexes to improve cascade operations (otherwise would do full table scan for each FK), nevermind any other relational lookup
- Use a bitset instead of a map for improved go memory performance 
- Select all instances, ports, and containers once instead of iterating over each instance

This ended up being some micro-improvements and optimizations along indexing and querying, free port mapping.

Here are some timings for everything in pre-computation phase of launching an instance, obviously the remote docker container launch is orders of magnitude greater. Main worst-case scenario is that DB size approaches limit of min-to-max port range, it would approach an infinite loop trying to find a new one. This was mostly addressed in the auto purge feature.

## Summary (Total Time in ms)

| DB Size | Baseline (pre #19 ) | Master (w/ #19) | Perf-Improvements |
|---------|-------------------|--------|-------------------|
|      20 |              0.31 |   0.32 |              0.33 |
|     200 |              0.44 |   0.42 |              0.29 |
|   20000 |             24.91 |  26.27 |             12.43 |
|   50000 |             60.51 |  64.76 |             31.43 |

Caching was briefly considered but frankly little to no gains for massive risk with introducing one in first place