### PR TITLE
Markdown challenge text round 2

### DIFF
--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -394,21 +394,29 @@ var voidTags = map[string]bool{
 	"track": true, "wbr": true,
 }
 
-var rawTagRe = regexp.MustCompile(`^<\s*(/?)\s*([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*?(/?)\s*>$`)
-
+// parseRawTag classifies a raw HTML tag using net/html's tokenizer rather
+// than a regex. A regex-based approach can't correctly handle quoted
+// attribute values that contain `>` (e.g. `<a title="x>y" href="z">`),
+// which would leave such tags unrecognized — and therefore unconverted,
+// letting unsafe attributes survive into the stored markdown.
 func parseRawTag(content string) (name string, kind int) {
-	m := rawTagRe.FindStringSubmatch(content)
-	if m == nil {
-		return "", 0
+	z := html.NewTokenizer(strings.NewReader(content))
+	switch z.Next() {
+	case html.StartTagToken:
+		b, _ := z.TagName()
+		n := strings.ToLower(string(b))
+		if voidTags[n] {
+			return n, tagSelfClosing
+		}
+		return n, tagOpen
+	case html.SelfClosingTagToken:
+		b, _ := z.TagName()
+		return strings.ToLower(string(b)), tagSelfClosing
+	case html.EndTagToken:
+		b, _ := z.TagName()
+		return strings.ToLower(string(b)), tagClose
 	}
-	name = strings.ToLower(m[2])
-	if m[1] == "/" {
-		return name, tagClose
-	}
-	if m[3] == "/" || voidTags[name] {
-		return name, tagSelfClosing
-	}
-	return name, tagOpen
+	return "", 0
 }
 
 // collectHTMLSpans walks the AST and returns byte ranges in src that should

--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -497,10 +497,9 @@ func pairInlineTags(tags []rawTag) []htmlSpan {
 			}
 			if matched >= 0 {
 				spans = append(spans, htmlSpan{stack[matched].start, t.end})
-				// Any unclosed openers above the match are orphans.
-				for _, orphan := range stack[matched+1:] {
-					spans = append(spans, htmlSpan{orphan.start, orphan.end})
-				}
+				// Discard any unclosed openers above the match. Emitting spans
+				// for them here would only create overlaps with the matched span,
+				// and those overlapping spans are skipped later.
 				stack = stack[:matched]
 			} else {
 				spans = append(spans, htmlSpan{t.start, t.end})

--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -16,18 +17,15 @@ import (
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/strikethrough"
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/table"
 	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/extension"
-	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/ast"
+	goldmarktext "github.com/yuin/goldmark/text"
 	"golang.org/x/net/html"
 	"gopkg.in/yaml.v2"
 )
 
 var (
-	markdownUnsafe = goldmark.New(
-		goldmark.WithExtensions(extension.GFM),
-		goldmark.WithRendererOptions(goldmarkhtml.WithUnsafe()),
-	)
-	htmlConverter = func() *converter.Converter {
+	markdownParser = goldmark.DefaultParser()
+	htmlConverter  = func() *converter.Converter {
 		c := converter.NewConverter(
 			converter.WithPlugins(
 				base.NewBasePlugin(),
@@ -40,12 +38,9 @@ var (
 				),
 			),
 		)
-		// Preserve <br> as an inline HTML tag in the markdown output. The
-		// default rule converts <br> to a paragraph break (two newlines),
-		// which collapses a markdown hard line break ("  \n") into a
-		// paragraph break during the round-trip. Emitting <br> keeps the
-		// line break inside the paragraph; CommonMark renderers treat
-		// inline <br> as a hard line break natively.
+		// Preserve <br> as an inline HTML tag in the converted output. The
+		// default rule turns <br> into a paragraph break (two newlines),
+		// which would collapse hard line breaks inside an HTML span.
 		c.Register.RendererFor("br", converter.TagTypeInline, renderBr, converter.PriorityEarly)
 		return c
 	}()
@@ -325,42 +320,187 @@ func (m *Manager) parseHints(lines []string) ([]string, error) {
 	return hints, err
 }
 
+// parseMarkdown returns the source with author-written HTML elements
+// converted to their markdown equivalents in place. Markdown syntax outside
+// of HTML islands (text, headings, emphasis, lists, code, templates, math,
+// backslash escapes, etc.) is passed through verbatim — the source is never
+// rendered through HTML, so nothing gets normalized, escaped, or reformatted
+// behind the author's back.
 func (m *Manager) parseMarkdown(text string) (string, error) {
-	// Templates like {{url_for('time.txt', 'here')}} contain characters
-	// (underscores, quotes) that the markdown round-trip would escape or
-	// HTML-encode, breaking downstream regex matching against the strict
-	// urlForRe/lookupRe/etc. patterns. Substitute each template with a
-	// neutral alphanumeric placeholder before rendering, restore them
-	// verbatim afterward.
-	templates := templateRe.FindAllString(text, -1)
-	for i, tmpl := range templates {
-		text = strings.Replace(text, tmpl, templatePlaceholder(i), 1)
-	}
+	src := []byte(text)
+	reader := goldmarktext.NewReader(src)
+	doc := markdownParser.Parse(reader)
 
-	// First pass: render markdown to HTML with raw HTML preserved, so any
-	// inline <code>, <a>, etc. in the source live alongside markdown-derived
-	// tags in a single HTML document.
-	var rawBuf bytes.Buffer
-	if err := markdownUnsafe.Convert([]byte(text), &rawBuf); err != nil {
-		return "", err
-	}
-
-	// Second pass: convert that HTML back to pure markdown. This normalizes
-	// raw HTML tags into their markdown equivalents and drops any tag with
-	// no markdown representation. The result is pure markdown for the
-	// frontend to render.
-	section, err := htmlConverter.ConvertString(rawBuf.String())
+	spans, err := collectHTMLSpans(doc, src)
 	if err != nil {
 		return "", err
 	}
-	section = strings.TrimSpace(section)
 
-	for i, tmpl := range templates {
-		section = strings.Replace(section, templatePlaceholder(i), tmpl, 1)
+	// Sort by start offset. Within a tie, the longer span wins (so a
+	// containing span is processed instead of an inner sibling). The
+	// pairing algorithm shouldn't emit overlapping spans, but the cursor
+	// check below guards against any straggler.
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start != spans[j].start {
+			return spans[i].start < spans[j].start
+		}
+		return spans[i].end > spans[j].end
+	})
+
+	var out bytes.Buffer
+	cursor := 0
+	for _, sp := range spans {
+		if sp.start < cursor {
+			continue
+		}
+		if sp.start > cursor {
+			out.Write(src[cursor:sp.start])
+		}
+		converted, err := htmlConverter.ConvertString(string(src[sp.start:sp.end]))
+		if err != nil {
+			return "", err
+		}
+		out.WriteString(converted)
+		cursor = sp.end
 	}
-	return section, nil
+	if cursor < len(src) {
+		out.Write(src[cursor:])
+	}
+
+	return strings.TrimSpace(out.String()), nil
 }
 
-func templatePlaceholder(i int) string {
-	return fmt.Sprintf("@@@%d@@@", i)
+type htmlSpan struct {
+	start, end int
+}
+
+type rawTag struct {
+	start, end int
+	name       string
+	kind       int
+}
+
+const (
+	tagOpen        = 1
+	tagClose       = 2
+	tagSelfClosing = 3
+)
+
+// HTML void elements: never have a closing tag. Per the WHATWG spec.
+var voidTags = map[string]bool{
+	"area": true, "base": true, "br": true, "col": true,
+	"embed": true, "hr": true, "img": true, "input": true,
+	"link": true, "meta": true, "param": true, "source": true,
+	"track": true, "wbr": true,
+}
+
+var rawTagRe = regexp.MustCompile(`^<\s*(/?)\s*([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*?(/?)\s*>$`)
+
+func parseRawTag(content string) (name string, kind int) {
+	m := rawTagRe.FindStringSubmatch(content)
+	if m == nil {
+		return "", 0
+	}
+	name = strings.ToLower(m[2])
+	if m[1] == "/" {
+		return name, tagClose
+	}
+	if m[3] == "/" || voidTags[name] {
+		return name, tagSelfClosing
+	}
+	return name, tagOpen
+}
+
+// collectHTMLSpans walks the AST and returns byte ranges in src that should
+// be substituted with their HTML→markdown converted form. HTMLBlock nodes
+// contribute their full span; inline RawHTML tags are paired open-with-close
+// via a stack so that `<a href="x">y</a>` resolves to one span covering both
+// tags and the text in between.
+func collectHTMLSpans(doc ast.Node, src []byte) ([]htmlSpan, error) {
+	var spans []htmlSpan
+	var inlineTags []rawTag
+
+	err := ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch n := n.(type) {
+		case *ast.HTMLBlock:
+			lines := n.Lines()
+			if lines.Len() > 0 {
+				start := lines.At(0).Start
+				end := lines.At(lines.Len() - 1).Stop
+				spans = append(spans, htmlSpan{start, end})
+			}
+			return ast.WalkSkipChildren, nil
+		case *ast.RawHTML:
+			segs := n.Segments
+			if segs == nil {
+				return ast.WalkContinue, nil
+			}
+			for i := 0; i < segs.Len(); i++ {
+				seg := segs.At(i)
+				content := string(src[seg.Start:seg.Stop])
+				name, kind := parseRawTag(content)
+				if kind == 0 {
+					// Comment, CDATA, doctype, processing instruction, etc.
+					// Skip — leave the source bytes untouched.
+					continue
+				}
+				inlineTags = append(inlineTags, rawTag{
+					start: seg.Start,
+					end:   seg.Stop,
+					name:  name,
+					kind:  kind,
+				})
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	spans = append(spans, pairInlineTags(inlineTags)...)
+	return spans, nil
+}
+
+// pairInlineTags consumes a source-ordered list of inline raw-HTML tags and
+// returns a list of spans. Open tags are paired with the next matching close
+// tag via a stack; unmatched openers/closers and void/self-closing tags each
+// form their own single-tag span.
+func pairInlineTags(tags []rawTag) []htmlSpan {
+	var spans []htmlSpan
+	var stack []rawTag
+
+	for _, t := range tags {
+		switch t.kind {
+		case tagSelfClosing:
+			spans = append(spans, htmlSpan{t.start, t.end})
+		case tagOpen:
+			stack = append(stack, t)
+		case tagClose:
+			matched := -1
+			for i := len(stack) - 1; i >= 0; i-- {
+				if stack[i].name == t.name {
+					matched = i
+					break
+				}
+			}
+			if matched >= 0 {
+				spans = append(spans, htmlSpan{stack[matched].start, t.end})
+				// Any unclosed openers above the match are orphans.
+				for _, orphan := range stack[matched+1:] {
+					spans = append(spans, htmlSpan{orphan.start, orphan.end})
+				}
+				stack = stack[:matched]
+			} else {
+				spans = append(spans, htmlSpan{t.start, t.end})
+			}
+		}
+	}
+	for _, orphan := range stack {
+		spans = append(spans, htmlSpan{orphan.start, orphan.end})
+	}
+	return spans
 }

--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -38,9 +38,8 @@ var (
 				),
 			),
 		)
-		// Preserve <br> as an inline HTML tag in the converted output. The
-		// default rule turns <br> into a paragraph break (two newlines),
-		// which would collapse hard line breaks inside an HTML span.
+		// Emit <br> as inline HTML so hard line breaks inside an HTML span
+		// don't collapse into paragraph breaks.
 		c.Register.RendererFor("br", converter.TagTypeInline, renderBr, converter.PriorityEarly)
 		return c
 	}()
@@ -321,11 +320,10 @@ func (m *Manager) parseHints(lines []string) ([]string, error) {
 }
 
 // parseMarkdown returns the source with author-written HTML elements
-// converted to their markdown equivalents in place. Markdown syntax outside
-// of HTML islands (text, headings, emphasis, lists, code, templates, math,
-// backslash escapes, etc.) is passed through verbatim — the source is never
-// rendered through HTML, so nothing gets normalized, escaped, or reformatted
-// behind the author's back.
+// converted in place to their markdown equivalents. Non-HTML markdown
+// (headings, emphasis, lists, code, math, templates, escapes) passes
+// through verbatim. The result is outer-trimmed of leading/trailing
+// whitespace.
 func (m *Manager) parseMarkdown(text string) (string, error) {
 	src := []byte(text)
 	reader := goldmarktext.NewReader(src)
@@ -336,10 +334,9 @@ func (m *Manager) parseMarkdown(text string) (string, error) {
 		return "", err
 	}
 
-	// Sort by start offset. Within a tie, the longer span wins (so a
-	// containing span is processed instead of an inner sibling). The
-	// pairing algorithm shouldn't emit overlapping spans, but the cursor
-	// check below guards against any straggler.
+	// Sort spans by start offset, longer spans winning on ties so nested
+	// HTML processes the outer span first. The cursor check below skips
+	// inner spans already consumed by an outer one.
 	sort.Slice(spans, func(i, j int) bool {
 		if spans[i].start != spans[j].start {
 			return spans[i].start < spans[j].start
@@ -394,11 +391,10 @@ var voidTags = map[string]bool{
 	"track": true, "wbr": true,
 }
 
-// parseRawTag classifies a raw HTML tag using net/html's tokenizer rather
-// than a regex. A regex-based approach can't correctly handle quoted
-// attribute values that contain `>` (e.g. `<a title="x>y" href="z">`),
-// which would leave such tags unrecognized — and therefore unconverted,
-// letting unsafe attributes survive into the stored markdown.
+// parseRawTag classifies a raw HTML tag via net/html's tokenizer. Returns
+// the lowercase tag name and one of tagOpen/tagClose/tagSelfClosing, or
+// ("", 0) for input that isn't a single recognizable tag (comments,
+// CDATA, doctypes, etc.).
 func parseRawTag(content string) (name string, kind int) {
 	z := html.NewTokenizer(strings.NewReader(content))
 	switch z.Next() {
@@ -451,8 +447,7 @@ func collectHTMLSpans(doc ast.Node, src []byte) ([]htmlSpan, error) {
 				content := string(src[seg.Start:seg.Stop])
 				name, kind := parseRawTag(content)
 				if kind == 0 {
-					// Comment, CDATA, doctype, processing instruction, etc.
-					// Skip — leave the source bytes untouched.
+					// Comment/CDATA/doctype/etc. — leave source bytes alone.
 					continue
 				}
 				inlineTags = append(inlineTags, rawTag{

--- a/cmgr/loader_markdown_test.go
+++ b/cmgr/loader_markdown_test.go
@@ -94,10 +94,8 @@ func TestParseMarkdownStripsUnsupportedHTML(t *testing.T) {
 		{"iframe tag", `<iframe src="evil"></iframe>`, []string{"<iframe", "evil"}},
 		{"style tag", "<style>body{color:red}</style>", []string{"<style", "color:red"}},
 		{"inline event handler", `<a href="x" onclick="evil()">link</a>`, []string{"onclick", "evil()"}},
-		// Regression: a tag with a `>` inside a quoted attribute value must
-		// still be classified as a tag and routed through the converter,
-		// not skipped over. Otherwise unsafe attributes (onclick, etc.)
-		// could ride along verbatim. See PR #64 review.
+		// `>` inside a quoted attribute value must not break tag
+		// classification — otherwise unsafe attrs ride along verbatim.
 		{"gt in quoted attribute", `<a title="x>y" href="z" onclick="evil()">link</a>`, []string{"onclick", "evil()"}},
 		{"gt in quoted attribute (single quotes)", `<a title='x>y' onerror='evil()'>link</a>`, []string{"onerror", "evil()"}},
 	}
@@ -169,10 +167,7 @@ func TestParseMarkdownPreservesParagraphsAndBreaks(t *testing.T) {
 	}
 }
 
-// TestParseMarkdownHTMLIslandBoundaries pins down behaviors at the seam
-// between HTML spans and surrounding markdown — the cases the islands-only
-// design implicitly relies on but doesn't make obvious from reading
-// parseMarkdown.
+// Behaviors at the seam between HTML spans and surrounding markdown.
 func TestParseMarkdownHTMLIslandBoundaries(t *testing.T) {
 	mgr := newTestManager()
 	tests := []struct {
@@ -182,27 +177,19 @@ func TestParseMarkdownHTMLIslandBoundaries(t *testing.T) {
 		excludes []string
 	}{
 		{
-			// HTML inside markdown emphasis: the inner span gets converted
-			// (<em>x</em> → _x_), but the outer asterisks are not an HTML
-			// island so they pass through verbatim.
+			// Inner HTML converts; outer markdown emphasis passes through.
 			name:     "html inside markdown emphasis",
 			input:    `*before <em>x</em> after*`,
 			contains: []string{`*before `, `_x_`, ` after*`},
 		},
 		{
-			// Goldmark treats fenced code blocks as opaque; no RawHTML
-			// nodes are emitted from inside them. The bytes pass through
-			// untouched, so <script> stays inert literal text inside the
-			// fence (it's not interpretable HTML at render time).
+			// Fenced code blocks are opaque — no HTML conversion inside.
 			name:     "html inside fenced code block is opaque",
 			input:    "```\n<script>bad</script>\n```",
 			contains: []string{"<script>bad</script>"},
 		},
 		{
-			// Nested HTML: the outer span fully contains the inner span.
-			// After sort (start asc, end desc) the outer runs first and
-			// the cursor check skips the inner span. v2 converts the whole
-			// nested structure in one shot.
+			// Outer span wins; inner span is byte-contained and skipped.
 			name:     "nested html collapses to outer span",
 			input:    `<a href="x"><strong>bold</strong></a>`,
 			contains: []string{"[**bold**](x)"},
@@ -483,39 +470,23 @@ func TestParseMarkdownPassesThroughVerbatim(t *testing.T) {
 	}
 }
 
-// TestParseMarkdownNoHTMLIsIdentity locks in the core invariant of the
-// islands-only parseMarkdown pipeline: if the input contains no raw HTML
-// tags, the output must equal the input byte-for-byte (modulo the outer
-// strings.TrimSpace that parseMarkdown applies). This is what guarantees
-// LaTeX / math / templates / backslash escapes / etc. survive untouched,
-// even for tricky patterns we haven't individually enumerated. If this
-// test fails, the loader is doing something to non-HTML markdown that it
-// shouldn't be.
+// Inputs with no HTML tags must round-trip identically (modulo outer
+// TrimSpace). This is the architectural guarantee that LaTeX, math,
+// templates, escapes etc. survive untouched.
 func TestParseMarkdownNoHTMLIsIdentity(t *testing.T) {
 	mgr := newTestManager()
 	inputs := []string{
-		// Inline and display math, including patterns that markdown would
-		// normally mangle: asterisks/underscores inside math, brace-flanked
-		// underscores, angle brackets in comparisons, backslash sequences.
 		"Plain text with $x_1$ and $x_2$ subscripts.",
 		"Display:\n\n$$\\sum_{i=1}^{n} a_i \\cdot b_i$$\n\nEnd.",
 		"Asterisk math: $a*b*c$, brace-flanked: ${a}_b_{c}$, comparison: $x < y$ and $a \\leq b$.",
 		"Greek: $\\alpha, \\beta, \\gamma$. Operators: $\\sum$, $\\int$, $\\prod$.",
 		"Frac and sub: $\\frac{x_1}{y_1}$, double sub: $a_{i,j}^{k+1}$.",
 		`Backslash escapes: \$5, \_under, \*star, \[bracket\].`,
-
-		// Emphasis-delimiter and structural syntax — verbatim, not normalized.
 		"Both emphasis forms: *one* and _two_ and **three** and __four__.",
 		"Hard break  \nbetween lines.",
 		"Horizontal rules: ---, ***, ___, three flavors.",
-
-		// Code (inline and fenced) — must pass through opaquely.
 		"Code: `inline` and\n\n```\nblock with $x_1$\n```\n\ndone.",
-
-		// Templates verbatim alongside math.
 		"Connect to {{server}}:{{port}} for $\\pi$ secrets.",
-
-		// Mixed structures: math inside list items, inside blockquotes.
 		"List:\n\n- math: $\\pi r^2$\n- code: `printf(\"%d\\n\", x)`\n- combo: $E=mc^2$\n",
 		"> Quoted: $\\int_0^\\infty e^{-x} dx = 1$.\n> Second quoted line with $x_1$.",
 	}

--- a/cmgr/loader_markdown_test.go
+++ b/cmgr/loader_markdown_test.go
@@ -94,6 +94,12 @@ func TestParseMarkdownStripsUnsupportedHTML(t *testing.T) {
 		{"iframe tag", `<iframe src="evil"></iframe>`, []string{"<iframe", "evil"}},
 		{"style tag", "<style>body{color:red}</style>", []string{"<style", "color:red"}},
 		{"inline event handler", `<a href="x" onclick="evil()">link</a>`, []string{"onclick", "evil()"}},
+		// Regression: a tag with a `>` inside a quoted attribute value must
+		// still be classified as a tag and routed through the converter,
+		// not skipped over. Otherwise unsafe attributes (onclick, etc.)
+		// could ride along verbatim. See PR #64 review.
+		{"gt in quoted attribute", `<a title="x>y" href="z" onclick="evil()">link</a>`, []string{"onclick", "evil()"}},
+		{"gt in quoted attribute (single quotes)", `<a title='x>y' onerror='evil()'>link</a>`, []string{"onerror", "evil()"}},
 	}
 
 	for _, tt := range tests {

--- a/cmgr/loader_markdown_test.go
+++ b/cmgr/loader_markdown_test.go
@@ -417,6 +417,54 @@ func TestParseMarkdownPassesThroughVerbatim(t *testing.T) {
 	}
 }
 
+// TestParseMarkdownNoHTMLIsIdentity locks in the core invariant of the
+// islands-only parseMarkdown pipeline: if the input contains no raw HTML
+// tags, the output must equal the input byte-for-byte (modulo the outer
+// strings.TrimSpace that parseMarkdown applies). This is what guarantees
+// LaTeX / math / templates / backslash escapes / etc. survive untouched,
+// even for tricky patterns we haven't individually enumerated. If this
+// test fails, the loader is doing something to non-HTML markdown that it
+// shouldn't be.
+func TestParseMarkdownNoHTMLIsIdentity(t *testing.T) {
+	mgr := newTestManager()
+	inputs := []string{
+		// Inline and display math, including patterns that markdown would
+		// normally mangle: asterisks/underscores inside math, brace-flanked
+		// underscores, angle brackets in comparisons, backslash sequences.
+		"Plain text with $x_1$ and $x_2$ subscripts.",
+		"Display:\n\n$$\\sum_{i=1}^{n} a_i \\cdot b_i$$\n\nEnd.",
+		"Asterisk math: $a*b*c$, brace-flanked: ${a}_b_{c}$, comparison: $x < y$ and $a \\leq b$.",
+		"Greek: $\\alpha, \\beta, \\gamma$. Operators: $\\sum$, $\\int$, $\\prod$.",
+		"Frac and sub: $\\frac{x_1}{y_1}$, double sub: $a_{i,j}^{k+1}$.",
+		`Backslash escapes: \$5, \_under, \*star, \[bracket\].`,
+
+		// Emphasis-delimiter and structural syntax — verbatim, not normalized.
+		"Both emphasis forms: *one* and _two_ and **three** and __four__.",
+		"Hard break  \nbetween lines.",
+		"Horizontal rules: ---, ***, ___, three flavors.",
+
+		// Code (inline and fenced) — must pass through opaquely.
+		"Code: `inline` and\n\n```\nblock with $x_1$\n```\n\ndone.",
+
+		// Templates verbatim alongside math.
+		"Connect to {{server}}:{{port}} for $\\pi$ secrets.",
+
+		// Mixed structures: math inside list items, inside blockquotes.
+		"List:\n\n- math: $\\pi r^2$\n- code: `printf(\"%d\\n\", x)`\n- combo: $E=mc^2$\n",
+		"> Quoted: $\\int_0^\\infty e^{-x} dx = 1$.\n> Second quoted line with $x_1$.",
+	}
+	for _, input := range inputs {
+		out, err := mgr.parseMarkdown(input)
+		if err != nil {
+			t.Fatalf("parseMarkdown(%q): %s", input, err)
+		}
+		want := strings.TrimSpace(input)
+		if out != want {
+			t.Errorf("not identity:\ninput:  %q\noutput: %q", input, out)
+		}
+	}
+}
+
 func TestParseBool(t *testing.T) {
 	trueCases := []string{"yes", "YES", "Yes", "true", "TRUE", "True", "1", "t", "T", "y", "Y"}
 	for _, tc := range trueCases {

--- a/cmgr/loader_markdown_test.go
+++ b/cmgr/loader_markdown_test.go
@@ -169,6 +169,66 @@ func TestParseMarkdownPreservesParagraphsAndBreaks(t *testing.T) {
 	}
 }
 
+// TestParseMarkdownHTMLIslandBoundaries pins down behaviors at the seam
+// between HTML spans and surrounding markdown — the cases the islands-only
+// design implicitly relies on but doesn't make obvious from reading
+// parseMarkdown.
+func TestParseMarkdownHTMLIslandBoundaries(t *testing.T) {
+	mgr := newTestManager()
+	tests := []struct {
+		name     string
+		input    string
+		contains []string
+		excludes []string
+	}{
+		{
+			// HTML inside markdown emphasis: the inner span gets converted
+			// (<em>x</em> → _x_), but the outer asterisks are not an HTML
+			// island so they pass through verbatim.
+			name:     "html inside markdown emphasis",
+			input:    `*before <em>x</em> after*`,
+			contains: []string{`*before `, `_x_`, ` after*`},
+		},
+		{
+			// Goldmark treats fenced code blocks as opaque; no RawHTML
+			// nodes are emitted from inside them. The bytes pass through
+			// untouched, so <script> stays inert literal text inside the
+			// fence (it's not interpretable HTML at render time).
+			name:     "html inside fenced code block is opaque",
+			input:    "```\n<script>bad</script>\n```",
+			contains: []string{"<script>bad</script>"},
+		},
+		{
+			// Nested HTML: the outer span fully contains the inner span.
+			// After sort (start asc, end desc) the outer runs first and
+			// the cursor check skips the inner span. v2 converts the whole
+			// nested structure in one shot.
+			name:     "nested html collapses to outer span",
+			input:    `<a href="x"><strong>bold</strong></a>`,
+			contains: []string{"[**bold**](x)"},
+			excludes: []string{"<a ", "<strong>", "</strong>", "</a>"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := mgr.parseMarkdown(tt.input)
+			if err != nil {
+				t.Fatalf("parseMarkdown error: %s", err)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\ngot: %q", want, out)
+				}
+			}
+			for _, bad := range tt.excludes {
+				if strings.Contains(out, bad) {
+					t.Errorf("output should not contain %q\ngot: %q", bad, out)
+				}
+			}
+		})
+	}
+}
+
 func TestParseMarkdownMixedSource(t *testing.T) {
 	mgr := newTestManager()
 	input := "# Title\n\nSome `inline` and <code>raw</code> code, plus [md link](https://md.example) and <a href=\"https://html.example\">html link</a>."

--- a/cmgr/loader_markdown_test.go
+++ b/cmgr/loader_markdown_test.go
@@ -23,11 +23,11 @@ func TestParseMarkdownNativeSyntax(t *testing.T) {
 		{"backtick inline code", "Use `foo` here.", []string{"`foo`"}},
 		{"fenced code block", "```\nhello\n```", []string{"```", "hello"}},
 		{"heading", "## A heading", []string{"## A heading"}},
-		{"bold and italic", "**bold** and *italic*", []string{"**bold**", "_italic_"}},
+		{"bold and italic", "**bold** and *italic*", []string{"**bold**", "*italic*"}},
 		{"unordered list", "- one\n- two", []string{"- one", "- two"}},
 		{"ordered list", "1. one\n2. two", []string{"1. one", "2. two"}},
 		{"link", "[example](https://example.com)", []string{"[example](https://example.com)"}},
-		{"horizontal rule", "before\n\n---\n\nafter", []string{"* * *"}},
+		{"horizontal rule", "before\n\n---\n\nafter", []string{"---"}},
 		{"blockquote", "> quoted", []string{"> quoted"}},
 	}
 
@@ -125,9 +125,9 @@ func TestParseMarkdownPreservesParagraphsAndBreaks(t *testing.T) {
 			contains: []string{"First paragraph.\n\nSecond paragraph.\n\nThird."},
 		},
 		{
-			name:     "md hard break preserved as <br>",
+			name:     "md hard break preserved verbatim",
 			input:    "Line one  \nLine two\n\nNew para.",
-			contains: []string{"Line one<br>", "Line two", "New para."},
+			contains: []string{"Line one  \nLine two", "New para."},
 			excludes: []string{"Line one\n\nLine two"},
 		},
 		{
@@ -376,6 +376,42 @@ func TestParseMarkdownPreservesTemplatesVerbatim(t *testing.T) {
 			}
 			if strings.Contains(out, "@@@") {
 				t.Errorf("placeholder leaked into output\ngot: %s", out)
+			}
+		})
+	}
+}
+
+func TestParseMarkdownPassesThroughVerbatim(t *testing.T) {
+	mgr := newTestManager()
+	// Markdown content outside of HTML tags must survive the parser
+	// untouched. No emphasis-delimiter substitution, no backslash escapes
+	// added, no whitespace reflowing, no entity encoding.
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"inline math", "Energy is $E = mc^2$ at rest.", "$E = mc^2$"},
+		{"subscript math", "Solve for $x_1$ and $x_2$.", "$x_1$"},
+		{"display math", "Display:\n\n$$\\sum_{i=1}^{n} a_i$$\n\nDone.", "$$\\sum_{i=1}^{n} a_i$$"},
+		{"math with asterisk", "Product: $a*b*c$ done.", "$a*b*c$"},
+		{"backslash escape", `Cost is \$5 today.`, `\$5`},
+		{"escaped underscore", `Use foo\_bar here.`, `foo\_bar`},
+		{"asterisk italic verbatim", "This is *italic* not _italic_.", "*italic*"},
+		{"underscore italic verbatim", "This is _italic_ not *italic*.", "_italic_"},
+		{"hr verbatim", "before\n\n---\n\nafter", "---"},
+		{"hr alt syntax verbatim", "before\n\n***\n\nafter", "***"},
+		{"hard break verbatim", "Line one  \nLine two", "Line one  \nLine two"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := mgr.parseMarkdown(tt.input)
+			if err != nil {
+				t.Fatalf("parseMarkdown error: %s", err)
+			}
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("output missing %q\ngot: %q", tt.want, out)
 			}
 		})
 	}

--- a/examples/specification.md
+++ b/examples/specification.md
@@ -14,8 +14,9 @@ in place to their Markdown equivalents before the field is stored, so
 `<code>`, `<a>`, `<em>`, `<strong>`, `<del>`, `<ul>`/`<ol>`/`<li>`,
 `<table>`, `<pre>`, `<hr>`, etc. are normalized to Markdown. Author-written
 attributes beyond what Markdown can express (`download`, `target`,
-`onclick`, `class`, `style`, etc.) are dropped along with their tags —
-only `href`/`title` on links and `src`/`alt`/`title` on images survive.
+`onclick`, `class`, `style`, etc.) are stripped during conversion, while
+the element itself is still normalized to Markdown where possible — only
+`href`/`title` on links and `src`/`alt`/`title` on images are retained.
 Tags with no Markdown equivalent (e.g. `<script>`, `<iframe>`, `<style>`)
 are dropped entirely. Markdown content outside of HTML tags is preserved
 verbatim — no escaping, no whitespace normalization, no emphasis-delimiter

--- a/examples/specification.md
+++ b/examples/specification.md
@@ -9,11 +9,25 @@
 
 `Description`, `Details`, and `Hints` are emitted as GitHub Flavored
 Markdown for the frontend to render. The source may freely mix Markdown
-syntax and raw HTML; any raw HTML is normalized to its Markdown
-equivalent before the field is stored, so `<code>`, `<a>`, `<em>`,
-`<strong>`, `<del>`, `<ul>`/`<ol>`/`<li>`, `<table>`, `<pre>`, `<hr>`,
-etc. all survive the round-trip as Markdown. Tags with no Markdown
-equivalent (e.g. `<script>` and most html attributes) are dropped.
+syntax and raw HTML; any author-written raw HTML elements are converted
+in place to their Markdown equivalents before the field is stored, so
+`<code>`, `<a>`, `<em>`, `<strong>`, `<del>`, `<ul>`/`<ol>`/`<li>`,
+`<table>`, `<pre>`, `<hr>`, etc. are normalized to Markdown. Author-written
+attributes beyond what Markdown can express (`download`, `target`,
+`onclick`, `class`, `style`, etc.) are dropped along with their tags —
+only `href`/`title` on links and `src`/`alt`/`title` on images survive.
+Tags with no Markdown equivalent (e.g. `<script>`, `<iframe>`, `<style>`)
+are dropped entirely. Markdown content outside of HTML tags is preserved
+verbatim — no escaping, no whitespace normalization, no emphasis-delimiter
+substitution — which means content like LaTeX (`$x_1$`, `$$\sum a_i$$`)
+and templated placeholders pass through untouched.
+
+The exception is the templated shortcuts (`{{url_for(...)}}`,
+`{{link(...)}}`, `{{link_as(...)}}`) described below: those expand to raw
+`<a>` HTML with `download` / `target='_blank'` after the markdown
+conversion has run, since markdown link syntax can't express those
+attributes. Authors cannot reproduce the same effect by writing
+`<a download>` directly — the conversion step will strip the attribute.
 
 `<h2>` tags are technically possible via html (the markdown version on the
 other hand will cause a structural collision for `problem.md`), but should

--- a/examples/specification.md
+++ b/examples/specification.md
@@ -19,9 +19,12 @@ the element itself is still normalized to Markdown where possible — only
 `href`/`title` on links and `src`/`alt`/`title` on images are retained.
 Tags with no Markdown equivalent (e.g. `<script>`, `<iframe>`, `<style>`)
 are dropped entirely. Markdown content outside of HTML tags is preserved
-verbatim — no escaping, no whitespace normalization, no emphasis-delimiter
+verbatim — no escaping, no entity encoding, no emphasis-delimiter
 substitution — which means content like LaTeX (`$x_1$`, `$$\sum a_i$$`)
-and templated placeholders pass through untouched.
+and templated placeholders pass through untouched. The only whitespace
+normalization applied is an outer trim on each stored field; in the
+`Hints` section, continuation lines are additionally de-indented so the
+hint body isn't read as an indented code block.
 
 The exception is the templated shortcuts (`{{url_for(...)}}`,
 `{{link(...)}}`, `{{link_as(...)}}`) described below: those expand to raw

--- a/examples/specification.md
+++ b/examples/specification.md
@@ -25,8 +25,8 @@ and templated placeholders pass through untouched.
 
 The exception is the templated shortcuts (`{{url_for(...)}}`,
 `{{link(...)}}`, `{{link_as(...)}}`) described below: those expand to raw
-`<a>` HTML with `download` / `target='_blank'` after the markdown
-conversion has run, since markdown link syntax can't express those
+`<a>` HTML with `download` / `target='_blank'` after the Markdown
+conversion has run, since Markdown link syntax can't express those
 attributes. Authors cannot reproduce the same effect by writing
 `<a download>` directly — the conversion step will strip the attribute.
 


### PR DESCRIPTION
This refactors a poorly implemented first round attempt to move challenge text to markdown in #62: convoluted pipeline of markdown -> html -> markdown now passes-through markdown and only convert html, allowing for latex markdown handling as well