### PR TITLE
fix: rebuild instances table to migrate legacy dbs

### DIFF
--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -1,11 +1,14 @@
 package cmgr
 
 import (
+	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"math/rand"
 	"os"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -232,38 +235,51 @@ func (m *Manager) initDatabase() error {
 		}
 	}
 
-	var colCount int
-	err = db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('instances') WHERE name = 'created_at';").Scan(&colCount)
+	// Bring an older `instances` table up to the current schema. created_at
+	// (DEFAULT CURRENT_TIMESTAMP) and is_finalized were both added after the
+	// original release. SQLite cannot ALTER ... ADD COLUMN a non-constant
+	// default such as CURRENT_TIMESTAMP, so any DB missing either column is
+	// migrated by rebuilding the table to match the canonical schema exactly.
+	var createdAtCols, isFinalizedCols int
+	err = db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('instances') WHERE name = 'created_at';").Scan(&createdAtCols)
 	if err != nil {
 		m.log.errorf("could not check instances table schema: %s", err)
 		return err
 	}
-	if colCount == 0 {
-		_, err = db.Exec("ALTER TABLE instances ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP;")
+	err = db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('instances') WHERE name = 'is_finalized';").Scan(&isFinalizedCols)
+	if err != nil {
+		m.log.errorf("could not check instances table schema for is_finalized: %s", err)
+		return err
+	}
+
+	// A pre-rebuild migration added is_finalized via ALTER ... DEFAULT 1, so on
+	// those upgraded DBs openInstance (which omits is_finalized) creates rows
+	// that are born finalized — the unfinalized-launch GC then never reclaims a
+	// crashed launch. The canonical schema uses DEFAULT 0, so a non-zero default
+	// also triggers a rebuild to restore it.
+	var isFinalizedDefault sql.NullString
+	if isFinalizedCols > 0 {
+		err = db.QueryRow("SELECT dflt_value FROM pragma_table_info('instances') WHERE name = 'is_finalized';").Scan(&isFinalizedDefault)
 		if err != nil {
+			m.log.errorf("could not check instances.is_finalized default: %s", err)
+			return err
+		}
+	}
+	staleIsFinalizedDefault := isFinalizedCols > 0 && isFinalizedDefault.String != "0"
+
+	if createdAtCols == 0 || isFinalizedCols == 0 || staleIsFinalizedDefault {
+		if err = rebuildInstancesTable(db, createdAtCols > 0, isFinalizedCols > 0); err != nil {
 			m.log.errorf("could not migrate instances table: %s", err)
 			return err
 		}
 	}
 
+	// instanceCreatedAtIndex is created here rather than in schemaQuery, so it
+	// must be ensured for fresh databases too (the rebuild path recreates it).
 	_, err = db.Exec("CREATE INDEX IF NOT EXISTS instanceCreatedAtIndex ON instances(created_at);")
 	if err != nil {
 		m.log.errorf("could not create instanceCreatedAtIndex index: %s", err)
 		return err
-	}
-
-	err = db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('instances') WHERE name = 'is_finalized';").Scan(&colCount)
-	if err != nil {
-		m.log.errorf("could not check instances table schema for is_finalized: %s", err)
-		return err
-	}
-	if colCount == 0 {
-		// Default to 1 for existing instances, as they were successfully launched
-		_, err = db.Exec("ALTER TABLE instances ADD COLUMN is_finalized INTEGER NOT NULL DEFAULT 1 CHECK(is_finalized IN (0,1));")
-		if err != nil {
-			m.log.errorf("could not migrate instances table for is_finalized: %s", err)
-			return err
-		}
 	}
 
 	var fkeysEnforced bool
@@ -287,6 +303,134 @@ func (m *Manager) initDatabase() error {
 	}
 
 	return nil
+}
+
+// rebuildInstancesTable recreates the `instances` table with the canonical
+// schema and copies existing rows across. It migrates databases that predate
+// the created_at and/or is_finalized columns, which cannot simply be added via
+// ALTER TABLE ... ADD COLUMN because created_at's DEFAULT CURRENT_TIMESTAMP is a
+// non-constant default that SQLite rejects in ADD COLUMN.
+//
+// `instances` is the target of ON DELETE CASCADE foreign keys (portAssignments,
+// containers), so the implicit DELETE that DROP TABLE performs would cascade and
+// destroy those rows if foreign keys were enforced. The rebuild therefore runs
+// with foreign_keys disabled. Because that pragma is per-connection and cannot
+// change inside a transaction, the whole operation is pinned to a single
+// connection: disable FKs, rebuild in a transaction, verify integrity with
+// foreign_key_check, commit, then re-enable FKs.
+func rebuildInstancesTable(db *sqlx.DB, hasCreatedAt, hasIsFinalized bool) (retErr error) {
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if _, err = conn.ExecContext(ctx, "PRAGMA foreign_keys=OFF;"); err != nil {
+		return err
+	}
+	// Restore enforcement before the connection returns to the pool (LIFO: runs
+	// before conn.Close). go-sqlite3 sets _fk only at open, not on checkout, so
+	// a connection left with foreign_keys=OFF would silently skip enforcement on
+	// reuse. Surface a re-enable failure so initDatabase aborts instead.
+	defer func() {
+		if _, e := conn.ExecContext(ctx, "PRAGMA foreign_keys=ON;"); e != nil && retErr == nil {
+			retErr = fmt.Errorf("could not re-enable foreign keys after rebuilding instances table: %w", e)
+		}
+	}()
+
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	const createNew = `CREATE TABLE instances_migrate_new (
+		id INTEGER PRIMARY KEY,
+		lastsolved INTEGER,
+		build INTEGER NOT NULL,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		is_finalized INTEGER NOT NULL DEFAULT 0 CHECK(is_finalized IN (0,1)),
+		FOREIGN KEY (build) REFERENCES builds (id)
+			ON UPDATE RESTRICT ON DELETE RESTRICT
+	);`
+	if _, err = tx.ExecContext(ctx, createNew); err != nil {
+		return err
+	}
+
+	// Synthesize values only for columns the old table lacks: backfill a missing
+	// created_at to now, and treat legacy instances as finalized (they were
+	// already launched), matching the semantics of the original incremental
+	// migration. When created_at already exists, copy it verbatim — preserving
+	// NULL, which the rest of the code treats as a valid "unknown" timestamp
+	// rather than rewriting it to now.
+	createdExpr := "CURRENT_TIMESTAMP"
+	if hasCreatedAt {
+		createdExpr = "created_at"
+	}
+	finalizedExpr := "1"
+	if hasIsFinalized {
+		finalizedExpr = "is_finalized"
+	}
+	copyStmt := fmt.Sprintf(
+		"INSERT INTO instances_migrate_new (id, lastsolved, build, created_at, is_finalized) "+
+			"SELECT id, lastsolved, build, %s, %s FROM instances;",
+		createdExpr, finalizedExpr,
+	)
+	if _, err = tx.ExecContext(ctx, copyStmt); err != nil {
+		return err
+	}
+
+	if _, err = tx.ExecContext(ctx, "DROP TABLE instances;"); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, "ALTER TABLE instances_migrate_new RENAME TO instances;"); err != nil {
+		return err
+	}
+
+	// Recreate the indexes that were dropped along with the old table.
+	if _, err = tx.ExecContext(ctx, "CREATE INDEX IF NOT EXISTS instanceBuildIndex ON instances(build);"); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, "CREATE INDEX IF NOT EXISTS instanceCreatedAtIndex ON instances(created_at);"); err != nil {
+		return err
+	}
+
+	// Confirm the rebuild left no dangling foreign-key references before
+	// committing (rows were copied with enforcement off).
+	rows, err := tx.QueryContext(ctx, "PRAGMA foreign_key_check;")
+	if err != nil {
+		return err
+	}
+	var violation string
+	if rows.Next() {
+		// foreign_key_check yields: table, rowid, parent (referenced table), fkid.
+		var (
+			table  string
+			rowid  sql.NullInt64
+			parent string
+			fkid   int
+		)
+		if err = rows.Scan(&table, &rowid, &parent, &fkid); err != nil {
+			rows.Close()
+			return err
+		}
+		rowidStr := "NULL"
+		if rowid.Valid {
+			rowidStr = strconv.FormatInt(rowid.Int64, 10)
+		}
+		violation = fmt.Sprintf("row %s in %q references a missing row in %q (fk %d)", rowidStr, table, parent, fkid)
+	}
+	if err = rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	if violation != "" {
+		return fmt.Errorf("foreign key check failed after rebuilding instances table: %s", violation)
+	}
+
+	return tx.Commit()
 }
 
 func (m *Manager) getReversePortMap(id ChallengeId) (map[string]string, error) {

--- a/cmgr/database_operations_test.go
+++ b/cmgr/database_operations_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // TestDatabaseChallengeRoundTrip tests adding, looking up, and removing challenges
@@ -1496,6 +1498,14 @@ func TestLookupBuildInstances(t *testing.T) {
 	})
 }
 
+// removeDBFiles deletes a SQLite database file along with the -wal and -shm
+// sidecar files that WAL mode can leave behind, so tests don't leak temp files.
+func removeDBFiles(path string) {
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		os.Remove(path + suffix)
+	}
+}
+
 // setupTestManager creates a Manager with a temporary on-disk database file for testing
 func setupTestManager(t *testing.T) *Manager {
 	t.Helper()
@@ -1505,9 +1515,7 @@ func setupTestManager(t *testing.T) *Manager {
 		t.Fatalf("failed to create temp file: %s", err)
 	}
 	dbFile.Close()
-	t.Cleanup(func() {
-		os.Remove(dbFile.Name())
-	})
+	t.Cleanup(func() { removeDBFiles(dbFile.Name()) })
 
 	mgr := new(Manager)
 	mgr.log = newLogger(DISABLED)
@@ -1520,4 +1528,266 @@ func setupTestManager(t *testing.T) *Manager {
 	}
 
 	return mgr
+}
+
+// openLegacyInstancesDB creates a temp database whose `instances` table omits
+// the created_at and/or is_finalized columns, simulating a schema from before
+// those columns existed. It also creates the portAssignments and containers
+// tables (which hold ON DELETE CASCADE foreign keys into instances) and seeds a
+// build, an instance, and one dependent row in each, so a rebuild's foreign-key
+// safety can be verified.
+func openLegacyInstancesDB(t *testing.T, withCreatedAt, withIsFinalized bool) *sqlx.DB {
+	t.Helper()
+
+	dbFile, err := os.CreateTemp("", "cmgr-migrate-*.db")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+	dbFile.Close()
+	t.Cleanup(func() { removeDBFiles(dbFile.Name()) })
+
+	dsn := dbFile.Name() + "?_fk=true&_journal_mode=WAL&_busy_timeout=50&_synchronous=NORMAL"
+	db, err := sqlx.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("failed to open db: %s", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	instanceCols := "id INTEGER PRIMARY KEY, lastsolved INTEGER, build INTEGER NOT NULL"
+	if withCreatedAt {
+		instanceCols += ", created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
+	}
+	if withIsFinalized {
+		instanceCols += ", is_finalized INTEGER NOT NULL DEFAULT 0 CHECK(is_finalized IN (0,1))"
+	}
+
+	schema := `
+	CREATE TABLE builds (id INTEGER PRIMARY KEY);
+	CREATE TABLE instances (
+		` + instanceCols + `,
+		FOREIGN KEY (build) REFERENCES builds (id) ON UPDATE RESTRICT ON DELETE RESTRICT
+	);
+	CREATE INDEX instanceBuildIndex ON instances(build);
+	CREATE TABLE portAssignments (
+		instance INTEGER NOT NULL,
+		name TEXT NOT NULL,
+		port INTEGER NOT NULL,
+		FOREIGN KEY (instance) REFERENCES instances (id) ON UPDATE RESTRICT ON DELETE CASCADE
+	);
+	CREATE TABLE containers (
+		instance INTEGER NOT NULL,
+		id TEXT NOT NULL PRIMARY KEY,
+		FOREIGN KEY (instance) REFERENCES instances (id) ON UPDATE RESTRICT ON DELETE CASCADE
+	);`
+	if withCreatedAt {
+		schema += "\n\tCREATE INDEX instanceCreatedAtIndex ON instances(created_at);"
+	}
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("failed to create legacy schema: %s", err)
+	}
+
+	seed := []string{
+		"INSERT INTO builds(id) VALUES (1);",
+		// created_at/is_finalized fall back to column defaults where present.
+		"INSERT INTO instances(id, lastsolved, build) VALUES (1, 0, 1);",
+		"INSERT INTO portAssignments(instance, name, port) VALUES (1, 'challenge', 12345);",
+		"INSERT INTO containers(instance, id) VALUES (1, 'deadbeefcafe');",
+	}
+	for _, stmt := range seed {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed failed (%q): %s", stmt, err)
+		}
+	}
+
+	return db
+}
+
+// TestRebuildInstancesTableMigration exercises the legacy-database migration
+// path directly: it rebuilds an old `instances` table to the current schema and
+// verifies the rows survive (including FK-dependent rows that ON DELETE CASCADE
+// would otherwise destroy), the new columns are populated with the correct
+// legacy semantics, and the restored DEFAULT CURRENT_TIMESTAMP works.
+func TestRebuildInstancesTableMigration(t *testing.T) {
+	cases := []struct {
+		name           string
+		hasCreatedAt   bool
+		hasIsFinalized bool
+	}{
+		{"legacy v1.2.0 (neither column)", false, false},
+		{"created_at only (pre-is_finalized)", true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openLegacyInstancesDB(t, tc.hasCreatedAt, tc.hasIsFinalized)
+
+			// When created_at already exists, a row may legitimately hold NULL
+			// (an "unknown" timestamp). The rebuild must copy it verbatim, not
+			// rewrite it to now.
+			if tc.hasCreatedAt {
+				if _, err := db.Exec("INSERT INTO instances(id, lastsolved, build, created_at) VALUES (3, 0, 1, NULL);"); err != nil {
+					t.Fatalf("seed NULL created_at instance: %s", err)
+				}
+			}
+
+			if err := rebuildInstancesTable(db, tc.hasCreatedAt, tc.hasIsFinalized); err != nil {
+				t.Fatalf("rebuildInstancesTable failed: %s", err)
+			}
+
+			// Both columns must exist after the rebuild.
+			for _, col := range []string{"created_at", "is_finalized"} {
+				var n int
+				if err := db.Get(&n, "SELECT COUNT(*) FROM pragma_table_info('instances') WHERE name = ?;", col); err != nil {
+					t.Fatalf("schema check for %s: %s", col, err)
+				}
+				if n != 1 {
+					t.Errorf("expected column %s to exist after migration", col)
+				}
+			}
+
+			// The instance row, and crucially its FK-dependent rows, must survive.
+			// If the rebuild ran with foreign keys enforced, DROP TABLE's implicit
+			// DELETE would have cascaded and wiped these.
+			for _, check := range []struct {
+				what  string
+				query string
+			}{
+				{"instance", "SELECT COUNT(*) FROM instances WHERE id = 1;"},
+				{"portAssignment", "SELECT COUNT(*) FROM portAssignments WHERE instance = 1;"},
+				{"container", "SELECT COUNT(*) FROM containers WHERE instance = 1;"},
+			} {
+				var n int
+				if err := db.Get(&n, check.query); err != nil {
+					t.Fatalf("%s count: %s", check.what, err)
+				}
+				if n != 1 {
+					t.Errorf("expected %s row to survive rebuild, found %d", check.what, n)
+				}
+			}
+
+			// Legacy rows are treated as finalized and get a backfilled timestamp.
+			var isFinalized int
+			var createdAt *time.Time
+			if err := db.QueryRow("SELECT is_finalized, created_at FROM instances WHERE id = 1;").Scan(&isFinalized, &createdAt); err != nil {
+				t.Fatalf("read migrated row: %s", err)
+			}
+			if isFinalized != 1 {
+				t.Errorf("expected legacy instance is_finalized=1, got %d", isFinalized)
+			}
+			if createdAt == nil {
+				t.Error("expected backfilled created_at, got NULL")
+			}
+
+			// The DEFAULT CURRENT_TIMESTAMP must be restored: an insert omitting
+			// created_at should still populate it.
+			if _, err := db.Exec("INSERT INTO instances(id, lastsolved, build) VALUES (2, 0, 1);"); err != nil {
+				t.Fatalf("insert new instance: %s", err)
+			}
+			var newCreatedAt *time.Time
+			if err := db.QueryRow("SELECT created_at FROM instances WHERE id = 2;").Scan(&newCreatedAt); err != nil {
+				t.Fatalf("read new row: %s", err)
+			}
+			if newCreatedAt == nil {
+				t.Error("expected restored DEFAULT CURRENT_TIMESTAMP to populate created_at on insert")
+			}
+
+			// A pre-existing NULL created_at must be preserved, not backfilled.
+			if tc.hasCreatedAt {
+				var preserved *time.Time
+				if err := db.QueryRow("SELECT created_at FROM instances WHERE id = 3;").Scan(&preserved); err != nil {
+					t.Fatalf("read preserved-NULL row: %s", err)
+				}
+				if preserved != nil {
+					t.Errorf("expected NULL created_at to survive rebuild as NULL, got %v", preserved)
+				}
+			}
+
+			// Foreign-key enforcement must still hold after the rebuild: a
+			// reference to a nonexistent instance should be rejected.
+			if _, err := db.Exec("INSERT INTO portAssignments(instance, name, port) VALUES (999, 'ghost', 23456);"); err == nil {
+				t.Error("expected foreign key violation after rebuild, insert succeeded")
+			}
+		})
+	}
+}
+
+// TestInitDatabaseRepairsStaleIsFinalizedDefault drives initDatabase against a
+// database in the buggy intermediate state: created_at and is_finalized both
+// exist, but is_finalized was added by the old ALTER ... DEFAULT 1 migration.
+// Because both columns are present, a column-existence-only trigger would skip
+// the rebuild and leave new instances born finalized (so the unfinalized-launch
+// GC never reclaims a crash). The migration must detect the non-canonical
+// default, rebuild to DEFAULT 0, preserve existing rows, and make newly opened
+// instances unfinalized.
+func TestInitDatabaseRepairsStaleIsFinalizedDefault(t *testing.T) {
+	dbFile, err := os.CreateTemp("", "cmgr-finalized-*.db")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+	dbFile.Close()
+	t.Cleanup(func() { removeDBFiles(dbFile.Name()) })
+
+	dsn := dbFile.Name() + "?_fk=true&_journal_mode=WAL&_busy_timeout=50&_synchronous=NORMAL"
+	seed, err := sqlx.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("failed to open seed db: %s", err)
+	}
+	// Mirror the pre-rebuild schema: created_at present, is_finalized added with
+	// the legacy DEFAULT 1. Seed one already-launched instance (default 1).
+	legacy := `
+	CREATE TABLE builds (id INTEGER PRIMARY KEY, schema TEXT);
+	CREATE TABLE instances (
+		id INTEGER PRIMARY KEY,
+		lastsolved INTEGER,
+		build INTEGER NOT NULL,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		is_finalized INTEGER NOT NULL DEFAULT 1 CHECK(is_finalized IN (0,1)),
+		FOREIGN KEY (build) REFERENCES builds (id) ON UPDATE RESTRICT ON DELETE RESTRICT
+	);
+	INSERT INTO builds(id) VALUES (1);
+	INSERT INTO instances(id, lastsolved, build) VALUES (1, 0, 1);`
+	if _, err := seed.Exec(legacy); err != nil {
+		t.Fatalf("failed to seed legacy schema: %s", err)
+	}
+	seed.Close()
+
+	mgr := new(Manager)
+	mgr.log = newLogger(DISABLED)
+	os.Setenv(DB_ENV, dbFile.Name())
+	defer os.Unsetenv(DB_ENV)
+	if err := mgr.initDatabase(); err != nil {
+		t.Fatalf("initDatabase failed: %s", err)
+	}
+	defer mgr.db.Close()
+
+	// The default must have been normalized to the canonical 0.
+	var dflt string
+	if err := mgr.db.QueryRow("SELECT dflt_value FROM pragma_table_info('instances') WHERE name = 'is_finalized';").Scan(&dflt); err != nil {
+		t.Fatalf("read is_finalized default: %s", err)
+	}
+	if dflt != "0" {
+		t.Errorf("expected is_finalized DEFAULT 0 after migration, got %q", dflt)
+	}
+
+	// The pre-existing launched instance must survive with is_finalized=1.
+	var existing int
+	if err := mgr.db.QueryRow("SELECT is_finalized FROM instances WHERE id = 1;").Scan(&existing); err != nil {
+		t.Fatalf("read existing instance: %s", err)
+	}
+	if existing != 1 {
+		t.Errorf("expected existing instance to keep is_finalized=1, got %d", existing)
+	}
+
+	// A newly opened instance (is_finalized omitted, as openInstance does) must
+	// now be born unfinalized so the GC can reclaim it if the launch crashes.
+	if _, err := mgr.db.Exec("INSERT INTO instances(id, lastsolved, build) VALUES (2, 0, 1);"); err != nil {
+		t.Fatalf("insert new instance: %s", err)
+	}
+	var fresh int
+	if err := mgr.db.QueryRow("SELECT is_finalized FROM instances WHERE id = 2;").Scan(&fresh); err != nil {
+		t.Fatalf("read new instance: %s", err)
+	}
+	if fresh != 0 {
+		t.Errorf("expected new instance to default to is_finalized=0, got %d", fresh)
+	}
 }


### PR DESCRIPTION
SQLite forbids non-constant defaults in ALTER TABLE ... ADD COLUMN, so the created_at migration (DEFAULT CURRENT_TIMESTAMP) failed on any database predating the column with "Cannot add a column with non-constant default". This broke upgrades from versions before created_at/is_finalized existed (e.g. v1.2.0).

Replace the per-column ALTERs with a single table rebuild that brings any old `instances` table to the canonical schema in one pass, restoring the DEFAULT CURRENT_TIMESTAMP clause. Because `instances` is the target of ON DELETE CASCADE foreign keys (portAssignments, containers), the rebuild runs the full SQLite procedure on a pinned connection: disable foreign keys, rebuild in a transaction (backfilling created_at to now and treating legacy instances as finalized), verify with foreign_key_check, commit, re-enable. Skipping the FK-off step would let DROP TABLE's implicit DELETE cascade and wipe live port reservations and container records.