### PR TITLE
fix(ci): check out before setup-go to cache Go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,15 +24,15 @@ jobs:
           - ubuntu-latest
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26.x'
         cache: true
       id: go
-
-    - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Get dependencies
       run: go mod download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,15 @@ jobs:
           - ubuntu-latest # amd64
           - macos-latest # arm64
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.x'
+          cache: true
         id: go
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build project
         run: |


### PR DESCRIPTION
setup-go keyed its cache on go.sum before checkout wrote it, so the module/build cache silently never restored. Ordering checkout first restores GOMODCACHE + GOCACHE across runs. Also enable caching on the release build job.