### PR TITLE
Content-address challenge image tags, `update --prune-old`

### DIFF
--- a/cmd/cmgr/challenges.go
+++ b/cmd/cmgr/challenges.go
@@ -93,6 +93,7 @@ func updateChallengeInfo(mgr *cmgr.Manager, args []string) int {
 	updateUsage(parser, "[<path>]")
 	verbose := parser.Bool("verbose", false, "print more information")
 	dryRun := parser.Bool("dry-run", false, "run the validation logic without updating the database or builds")
+	pruneOld := parser.Bool("prune-old", false, "remove image generations older than each build's retained rollback generation (off by default in case another cmgr instance on this docker daemon references them)")
 	parser.Parse(args)
 
 	if parser.NArg() > 1 {
@@ -114,7 +115,7 @@ func updateChallengeInfo(mgr *cmgr.Manager, args []string) int {
 	if *dryRun {
 		updates = mgr.DetectChanges(path)
 	} else {
-		updates = mgr.Update(path)
+		updates = mgr.UpdateWithOptions(path, cmgr.UpdateOptions{PruneOldImages: *pruneOld})
 	}
 
 	printChanges(updates, *verbose)

--- a/cmd/cmgr/challenges.go
+++ b/cmd/cmgr/challenges.go
@@ -93,7 +93,7 @@ func updateChallengeInfo(mgr *cmgr.Manager, args []string) int {
 	updateUsage(parser, "[<path>]")
 	verbose := parser.Bool("verbose", false, "print more information")
 	dryRun := parser.Bool("dry-run", false, "run the validation logic without updating the database or builds")
-	pruneOld := parser.Bool("prune-old", false, "remove image generations older than each build's retained rollback generation (off by default in case another cmgr instance on this docker daemon references them)")
+	pruneOld := parser.Bool("prune-old", false, "untag the image generation each rebuild displaces from its rollback slot (only what this update displaces, not older strays; off by default in case another cmgr instance on this docker daemon references it)")
 	parser.Parse(args)
 
 	if parser.NArg() > 1 {

--- a/cmd/cmgr/main.go
+++ b/cmd/cmgr/main.go
@@ -139,7 +139,10 @@ Available commands:
   update [<path>]
       updates the metadata for all challenges underneath the provided path and
       rebuilds/restarts and existing builds/insances of those challenges; path
-      defaults to the root challenge directory if omitted
+      defaults to the root challenge directory if omitted; '--prune-old'
+      additionally removes image generations older than each build's retained
+      rollback generation and '--dry-run' reports changes without applying
+      anything
 
   freeze <challenge>
       for challenge formats that support it, creates a base container image

--- a/cmd/cmgr/main.go
+++ b/cmd/cmgr/main.go
@@ -138,11 +138,11 @@ Available commands:
 
   update [<path>]
       updates the metadata for all challenges underneath the provided path and
-      rebuilds/restarts and existing builds/insances of those challenges; path
-      defaults to the root challenge directory if omitted; '--prune-old'
-      additionally removes image generations older than each build's retained
-      rollback generation and '--dry-run' reports changes without applying
-      anything
+      rebuilds/restarts any existing builds/instances of those challenges; path
+      defaults to the root challenge directory if omitted; '--prune-old' untags
+      the image generation each rebuild displaces from its rollback slot (only
+      generations displaced by this update, not older strays) and '--dry-run'
+      reports changes without applying anything
 
   freeze <challenge>
       for challenge formats that support it, creates a base container image

--- a/cmd/cmgrd/swagger.yaml
+++ b/cmd/cmgrd/swagger.yaml
@@ -418,6 +418,20 @@ definitions:
         format: int32
       format:
         type: string
+      checksum:
+        type: integer
+        format: int64
+        description: >
+          Content identity of the build's images (an unsigned 32-bit CRC over
+          the challenge source checksum and flag format). Embedded in the
+          images' docker tags; omitted when not yet determined.
+      prev_checksum:
+        type: integer
+        format: int64
+        description: >
+          The image generation displaced on the last rebuild, retained as a
+          rollback target. Omitted when there is no retained rollback
+          generation.
       images:
         type: array
         items:

--- a/cmgr/api.go
+++ b/cmgr/api.go
@@ -127,14 +127,16 @@ func (m *Manager) DetectChanges(fp string) *ChallengeUpdates {
 
 // UpdateOptions adjusts the behavior of `UpdateWithOptions`.
 type UpdateOptions struct {
-	// PruneOldImages removes image generations that fall out of retention when
-	// a rebuild lands: each build keeps its new images plus the generation it
+	// PruneOldImages untags the image generation a rebuild displaces from its
+	// rollback slot: each build keeps its new images plus the generation it
 	// just replaced (the rollback target, see BuildMetadata.PrevChecksum), and
-	// anything older is untagged once the new images are finalized and any
-	// instances restarted. Off by default: a tag can be referenced outside
-	// this cmgr database (e.g. another cmgr instance on the same docker
-	// daemon that built identical content), and cmgr cannot see those
-	// references.
+	// the one pushed beyond that is untagged after all of the challenge's builds
+	// are processed. Only generations displaced by THIS update are removed —
+	// generations orphaned by earlier updates that ran without this flag are
+	// not tracked and are not reclaimed here. Off by default: a tag can be
+	// referenced outside this cmgr database (e.g. another cmgr instance on the
+	// same docker daemon that built identical content), and cmgr cannot see
+	// those references.
 	PruneOldImages bool
 }
 
@@ -155,8 +157,8 @@ func (m *Manager) Update(fp string) *ChallengeUpdates {
 	return m.UpdateWithOptions(fp, UpdateOptions{})
 }
 
-// Identical to `Update` but with explicit options; `Update` is equivalent to
-// calling this with the zero-value `UpdateOptions`.
+// UpdateWithOptions is identical to Update but takes explicit options; Update
+// is equivalent to calling this with the zero-value UpdateOptions.
 func (m *Manager) UpdateWithOptions(fp string, options UpdateOptions) *ChallengeUpdates {
 	cu := m.DetectChanges(fp)
 	errs := m.addChallenges(cu.Added)

--- a/cmgr/api.go
+++ b/cmgr/api.go
@@ -125,6 +125,19 @@ func (m *Manager) DetectChanges(fp string) *ChallengeUpdates {
 	return cu
 }
 
+// UpdateOptions adjusts the behavior of `UpdateWithOptions`.
+type UpdateOptions struct {
+	// PruneOldImages removes image generations that fall out of retention when
+	// a rebuild lands: each build keeps its new images plus the generation it
+	// just replaced (the rollback target, see BuildMetadata.PrevChecksum), and
+	// anything older is untagged once the new images are finalized and any
+	// instances restarted. Off by default: a tag can be referenced outside
+	// this cmgr database (e.g. another cmgr instance on the same docker
+	// daemon that built identical content), and cmgr cannot see those
+	// references.
+	PruneOldImages bool
+}
+
 // This will update the global system state based off the changes that are
 // detected by a call to `DetectChanges`.  Specifically, in addition to
 // updating challenge metadata (new and existing) it will rebuild and, if
@@ -139,18 +152,24 @@ func (m *Manager) DetectChanges(fp string) *ChallengeUpdates {
 // perform any removals of challenge metadata (removing a built challenge is
 // considered an error).
 func (m *Manager) Update(fp string) *ChallengeUpdates {
+	return m.UpdateWithOptions(fp, UpdateOptions{})
+}
+
+// Identical to `Update` but with explicit options; `Update` is equivalent to
+// calling this with the zero-value `UpdateOptions`.
+func (m *Manager) UpdateWithOptions(fp string, options UpdateOptions) *ChallengeUpdates {
 	cu := m.DetectChanges(fp)
 	errs := m.addChallenges(cu.Added)
 	if len(errs) != 0 {
 		cu.Errors = append(cu.Errors, errs...)
 	}
 
-	errs = m.updateChallenges(cu.Refreshed, false)
+	errs = m.updateChallenges(cu.Refreshed, false, false)
 	if len(errs) != 0 {
 		cu.Errors = append(cu.Errors, errs...)
 	}
 
-	errs = m.updateChallenges(cu.Updated, true)
+	errs = m.updateChallenges(cu.Updated, true, options.PruneOldImages)
 	if len(errs) != 0 {
 		cu.Errors = append(cu.Errors, errs...)
 	}

--- a/cmgr/content_tag_test.go
+++ b/cmgr/content_tag_test.go
@@ -1,0 +1,210 @@
+package cmgr
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func TestContentChecksum(t *testing.T) {
+	base := contentChecksum(0xdeadbeef, "flag{%s}")
+	if base != contentChecksum(0xdeadbeef, "flag{%s}") {
+		t.Error("contentChecksum is not deterministic")
+	}
+	if base == contentChecksum(0xdeadbef0, "flag{%s}") {
+		t.Error("expected different checksum for a different source checksum")
+	}
+	if base == contentChecksum(0xdeadbeef, "ctf{%s}") {
+		t.Error("expected different checksum for a different flag format")
+	}
+}
+
+func TestDockerIdContentAddressed(t *testing.T) {
+	image := Image{Host: "challenge"}
+
+	a := &BuildMetadata{Id: 1, Seed: 3, Checksum: 0xdeadbeef}
+	if got, want := a.dockerId(image), "s3-deadbeef-challenge"; got != want {
+		t.Errorf("dockerId = %q, want %q", got, want)
+	}
+
+	// Negative seeds must still yield a tag with a valid leading character.
+	b := &BuildMetadata{Id: 2, Seed: -7, Checksum: 0xdeadbeef}
+	if got, want := b.dockerId(image), "s-7-deadbeef-challenge"; got != want {
+		t.Errorf("dockerId = %q, want %q", got, want)
+	}
+
+	// The local build id must not influence the tag: identical content built
+	// under different ids (e.g. by different cmgr databases) shares a tag.
+	c := &BuildMetadata{Id: 99, Seed: 3, Checksum: 0xdeadbeef}
+	if a.dockerId(image) != c.dockerId(image) {
+		t.Error("dockerId must not depend on the build id")
+	}
+}
+
+// insertTestBuild inserts a builds row directly and returns its id.
+func insertTestBuild(t *testing.T, mgr *Manager, schema, challenge, format string, seed int, checksum uint32) BuildId {
+	t.Helper()
+	res, err := mgr.db.Exec(
+		`INSERT INTO builds(flag, format, seed, checksum, hasartifacts, lastsolved, challenge, schema, instancecount)
+		 VALUES ('flag{x}', ?, ?, ?, 0, 0, ?, ?, 1);`,
+		format, seed, checksum, challenge, schema)
+	if err != nil {
+		t.Fatalf("failed to insert build: %s", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("failed to read build id: %s", err)
+	}
+	return BuildId(id)
+}
+
+func TestContentReferenced(t *testing.T) {
+	mgr := setupTestManager(t)
+	defer mgr.db.Close()
+
+	challenge := &ChallengeMetadata{
+		Id:            "test/shared-content",
+		Name:          "Shared Content",
+		Namespace:     "test",
+		ChallengeType: "custom",
+		Path:          "/tmp/test/problem.md",
+		Hosts:         []HostInfo{{Name: "challenge", Target: ""}},
+		PortMap:       map[string]PortInfo{},
+	}
+	if errs := mgr.addChallenges([]*ChallengeMetadata{challenge}); len(errs) > 0 {
+		t.Fatalf("addChallenges failed: %v", errs)
+	}
+
+	const format = "flag{%s}"
+	const seed = 42
+	const checksum = uint32(0xabad1dea)
+
+	// Two schemas holding the same (challenge, seed, format, checksum) tuple
+	// resolve to the same docker tags.
+	idA := insertTestBuild(t, mgr, "event-a", "test/shared-content", format, seed, checksum)
+	idB := insertTestBuild(t, mgr, "event-b", "test/shared-content", format, seed, checksum)
+
+	shared := &BuildMetadata{Challenge: "test/shared-content", Seed: seed, Format: format, Checksum: checksum}
+	if !mgr.contentReferenced(shared, idA) {
+		t.Error("expected content to be referenced while a second build shares the tuple")
+	}
+
+	if _, err := mgr.db.Exec("DELETE FROM builds WHERE id = ?;", idB); err != nil {
+		t.Fatalf("failed to delete build: %s", err)
+	}
+	if mgr.contentReferenced(shared, idA) {
+		t.Error("expected content to be unreferenced once the sharing build is gone")
+	}
+
+	// A build of the same challenge and seed but a different generation
+	// (checksum) has different tags and must not count as a reference.
+	insertTestBuild(t, mgr, "event-b", "test/shared-content", format, seed, checksum+1)
+	if mgr.contentReferenced(shared, idA) {
+		t.Error("expected a different-checksum build not to count as a reference")
+	}
+}
+
+// TestBuildsChecksumMigration exercises the legacy-database migration path: a
+// builds table from before the checksum column existed must gain the column
+// and have its rows backfilled from the owning challenge's source checksum
+// and the row's flag format. (Image retagging is skipped because the test
+// manager has no docker client.)
+func TestBuildsChecksumMigration(t *testing.T) {
+	dbFile, err := os.CreateTemp("", "cmgr-test-*.db")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+	dbFile.Close()
+	t.Cleanup(func() { removeDBFiles(dbFile.Name()) })
+
+	seedDB, err := sqlx.Open("sqlite3", dbFile.Name())
+	if err != nil {
+		t.Fatalf("failed to open seed database: %s", err)
+	}
+
+	const sourceChecksum = uint32(0x1234abcd)
+	const format = "flag{%s}"
+
+	// The pre-checksum shape of the challenges/builds/images tables.
+	legacy := `
+	CREATE TABLE challenges (
+		id TEXT NOT NULL PRIMARY KEY,
+		name TEXT NOT NULL,
+		namespace TEXT NOT NULL,
+		challengetype TEXT NOT NULL,
+		description TEXT NOT NULL,
+		details TEXT,
+		sourcechecksum INT NOT NULL,
+		metadatachecksum INT NOT NULL,
+		path TEXT NOT NULL,
+		solvescript INTEGER NOT NULL,
+		templatable INTEGER NOT NULL,
+		maxusers INTEGER NOT NULL,
+		category TEXT,
+		points INTEGER NOT NULL
+	);
+	CREATE TABLE builds (
+		id INTEGER PRIMARY KEY,
+		flag TEXT NOT NULL,
+		format TEXT NOT NULL,
+		seed INTEGER NOT NULL,
+		hasartifacts INTEGER NOT NULL,
+		lastsolved INTEGER,
+		challenge TEXT NOT NULL,
+		schema TEXT NOT NULL,
+		instancecount INT NOT NULL,
+		UNIQUE(schema, format, challenge, seed),
+		FOREIGN KEY (challenge) REFERENCES challenges (id)
+	);
+	CREATE TABLE images (
+		id INTEGER PRIMARY KEY,
+		build INTEGER NOT NULL,
+		host TEXT NOT NULL,
+		FOREIGN KEY (build) REFERENCES builds (id)
+	);`
+	if _, err := seedDB.Exec(legacy); err != nil {
+		t.Fatalf("failed to create legacy schema: %s", err)
+	}
+	if _, err := seedDB.Exec(
+		`INSERT INTO challenges(id, name, namespace, challengetype, description, sourcechecksum, metadatachecksum, path, solvescript, templatable, maxusers, points)
+		 VALUES ('test/legacy', 'Legacy', 'test', 'custom', '', ?, 0, '/tmp/legacy/problem.md', 0, 0, 0, 0);`,
+		sourceChecksum); err != nil {
+		t.Fatalf("failed to seed challenge: %s", err)
+	}
+	if _, err := seedDB.Exec(
+		`INSERT INTO builds(id, flag, format, seed, hasartifacts, lastsolved, challenge, schema, instancecount)
+		 VALUES (1, 'flag{x}', ?, 7, 0, 0, 'test/legacy', 'event', 1);`, format); err != nil {
+		t.Fatalf("failed to seed build: %s", err)
+	}
+	if _, err := seedDB.Exec("INSERT INTO images(build, host) VALUES (1, 'challenge');"); err != nil {
+		t.Fatalf("failed to seed image: %s", err)
+	}
+	seedDB.Close()
+
+	mgr := new(Manager)
+	mgr.log = newLogger(DISABLED)
+	os.Setenv(DB_ENV, dbFile.Name())
+	defer os.Unsetenv(DB_ENV)
+	if err := mgr.initDatabase(); err != nil {
+		t.Fatalf("initDatabase failed: %s", err)
+	}
+	defer mgr.db.Close()
+
+	var got uint32
+	if err := mgr.db.Get(&got, "SELECT checksum FROM builds WHERE id = 1;"); err != nil {
+		t.Fatalf("failed to read migrated checksum: %s", err)
+	}
+	if want := contentChecksum(sourceChecksum, format); got != want {
+		t.Errorf("migrated checksum = %#x, want %#x", got, want)
+	}
+
+	// The migrated row must round-trip through the normal lookup path.
+	bMeta, err := mgr.lookupBuildMetadata(1)
+	if err != nil {
+		t.Fatalf("lookupBuildMetadata failed: %s", err)
+	}
+	if bMeta.Checksum != contentChecksum(sourceChecksum, format) {
+		t.Errorf("lookup returned checksum %#x, want %#x", bMeta.Checksum, contentChecksum(sourceChecksum, format))
+	}
+}

--- a/cmgr/content_tag_test.go
+++ b/cmgr/content_tag_test.go
@@ -103,6 +103,15 @@ func TestContentReferenced(t *testing.T) {
 	if mgr.contentReferenced(shared, idA) {
 		t.Error("expected a different-checksum build not to count as a reference")
 	}
+
+	// A build retaining the tuple's checksum as its rollback generation
+	// (prevchecksum) must also keep the images alive.
+	if _, err := mgr.db.Exec("UPDATE builds SET prevchecksum = ? WHERE schema = 'event-b';", checksum); err != nil {
+		t.Fatalf("failed to set prevchecksum: %s", err)
+	}
+	if !mgr.contentReferenced(shared, idA) {
+		t.Error("expected a rollback-generation reference to keep content referenced")
+	}
 }
 
 // TestBuildsChecksumMigration exercises the legacy-database migration path: a
@@ -199,12 +208,16 @@ func TestBuildsChecksumMigration(t *testing.T) {
 		t.Errorf("migrated checksum = %#x, want %#x", got, want)
 	}
 
-	// The migrated row must round-trip through the normal lookup path.
+	// The migrated row must round-trip through the normal lookup path, with
+	// the rollback generation unset (unknowable for pre-migration rows).
 	bMeta, err := mgr.lookupBuildMetadata(1)
 	if err != nil {
 		t.Fatalf("lookupBuildMetadata failed: %s", err)
 	}
 	if bMeta.Checksum != contentChecksum(sourceChecksum, format) {
 		t.Errorf("lookup returned checksum %#x, want %#x", bMeta.Checksum, contentChecksum(sourceChecksum, format))
+	}
+	if bMeta.PrevChecksum != 0 {
+		t.Errorf("lookup returned prevchecksum %#x, want 0", bMeta.PrevChecksum)
 	}
 }

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -241,8 +241,12 @@ func (m *Manager) initDatabase() error {
 
 	// Migrate older DBs: add builds.checksum, the content identity embedded in
 	// each build's docker tags. Rows predating the column are backfilled and
-	// their local images retagged from the legacy id-based tag form so
-	// existing deployments keep launching without a rebuild.
+	// their local images retagged from the legacy id-based tag form so existing
+	// deployments keep launching without a rebuild. The column is added once,
+	// but the backfill is driven by data (rows still at the default checksum=0)
+	// and runs on every start until it completes: a crash or transient docker
+	// error mid-migration leaves the affected rows at 0 and they are retried
+	// next start, rather than being skipped forever by a column-existence guard.
 	var buildsChecksumCols int
 	err = db.QueryRow("SELECT COUNT(1) FROM pragma_table_info('builds') WHERE name='checksum';").Scan(&buildsChecksumCols)
 	if err != nil {
@@ -255,10 +259,10 @@ func (m *Manager) initDatabase() error {
 			m.log.errorf("could not migrate builds.checksum column: %s", err)
 			return err
 		}
-		if err = m.migrateBuildChecksums(db); err != nil {
-			m.log.errorf("could not backfill builds.checksum: %s", err)
-			return err
-		}
+	}
+	if err = m.migrateBuildChecksums(db); err != nil {
+		m.log.errorf("could not backfill builds.checksum: %s", err)
+		return err
 	}
 
 	// builds.prevchecksum records the generation retained for rollback (0 =

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -93,6 +93,7 @@ const schemaQuery string = `
 		flag TEXT NOT NULL,
 		format TEXT NOT NULL,
 		seed INTEGER NOT NULL,
+		checksum INTEGER NOT NULL DEFAULT 0,
 		hasartifacts INTEGER NOT NULL CHECK (hasartifacts = 0 OR hasartifacts = 1),
 		lastsolved INTEGER,
 		challenge TEXT NOT NULL,
@@ -233,6 +234,28 @@ func (m *Manager) initDatabase() error {
 		_, err = db.Exec("ALTER TABLE containerOptions ADD COLUMN capimmutable INTEGER NOT NULL DEFAULT 0;")
 		if err != nil {
 			m.log.errorf("could not migrate containerOptions.capimmutable column: %s", err)
+			return err
+		}
+	}
+
+	// Migrate older DBs: add builds.checksum, the content identity embedded in
+	// each build's docker tags. Rows predating the column are backfilled and
+	// their local images retagged from the legacy id-based tag form so
+	// existing deployments keep launching without a rebuild.
+	var buildsChecksumCols int
+	err = db.QueryRow("SELECT COUNT(1) FROM pragma_table_info('builds') WHERE name='checksum';").Scan(&buildsChecksumCols)
+	if err != nil {
+		m.log.errorf("could not inspect builds schema: %s", err)
+		return err
+	}
+	if buildsChecksumCols == 0 {
+		_, err = db.Exec("ALTER TABLE builds ADD COLUMN checksum INTEGER NOT NULL DEFAULT 0;")
+		if err != nil {
+			m.log.errorf("could not migrate builds.checksum column: %s", err)
+			return err
+		}
+		if err = m.migrateBuildChecksums(db); err != nil {
+			m.log.errorf("could not backfill builds.checksum: %s", err)
 			return err
 		}
 	}

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -94,6 +94,7 @@ const schemaQuery string = `
 		format TEXT NOT NULL,
 		seed INTEGER NOT NULL,
 		checksum INTEGER NOT NULL DEFAULT 0,
+		prevchecksum INTEGER NOT NULL DEFAULT 0,
 		hasartifacts INTEGER NOT NULL CHECK (hasartifacts = 0 OR hasartifacts = 1),
 		lastsolved INTEGER,
 		challenge TEXT NOT NULL,
@@ -256,6 +257,22 @@ func (m *Manager) initDatabase() error {
 		}
 		if err = m.migrateBuildChecksums(db); err != nil {
 			m.log.errorf("could not backfill builds.checksum: %s", err)
+			return err
+		}
+	}
+
+	// builds.prevchecksum records the generation retained for rollback (0 =
+	// none known); no backfill is possible for rows that predate it.
+	var prevChecksumCols int
+	err = db.QueryRow("SELECT COUNT(1) FROM pragma_table_info('builds') WHERE name='prevchecksum';").Scan(&prevChecksumCols)
+	if err != nil {
+		m.log.errorf("could not inspect builds schema: %s", err)
+		return err
+	}
+	if prevChecksumCols == 0 {
+		_, err = db.Exec("ALTER TABLE builds ADD COLUMN prevchecksum INTEGER NOT NULL DEFAULT 0;")
+		if err != nil {
+			m.log.errorf("could not migrate builds.prevchecksum column: %s", err)
 			return err
 		}
 	}

--- a/cmgr/database_builds.go
+++ b/cmgr/database_builds.go
@@ -38,13 +38,13 @@ func (m *Manager) openBuild(build *BuildMetadata) error {
 	}
 
 	m.log.debug("Running select...")
-	rows, err := m.db.NamedQuery("SELECT id, flag, hasartifacts, lastsolved, checksum FROM builds WHERE schema=:schema AND format=:format AND challenge=:challenge AND seed=:seed;", build)
+	rows, err := m.db.NamedQuery("SELECT id, flag, hasartifacts, lastsolved, checksum, prevchecksum FROM builds WHERE schema=:schema AND format=:format AND challenge=:challenge AND seed=:seed;", build)
 	if err != nil {
 		m.log.errorf("failed to find build: %s", err)
 	} else if !rows.Next() {
 		m.log.error("found no rows when exactly one expected")
 	}
-	err = rows.Scan(&build.Id, &build.Flag, &build.HasArtifacts, &build.LastSolved, &build.Checksum)
+	err = rows.Scan(&build.Id, &build.Flag, &build.HasArtifacts, &build.LastSolved, &build.Checksum, &build.PrevChecksum)
 	if err != nil {
 		m.log.errorf("failed to read build ID: %s", err)
 	}
@@ -63,6 +63,7 @@ const finalizeBuildQuery string = `
 		flag = :flag,
 		hasartifacts = :hasartifacts,
 		checksum = :checksum,
+		prevchecksum = :prevchecksum,
 		lastsolved = 0
 	WHERE id = :id;`
 
@@ -193,16 +194,17 @@ func (m *Manager) finalizeBuild(build *BuildMetadata) error {
 }
 
 // contentReferenced reports whether a build row other than excludeBuild
-// resolves to the same docker tags as bMeta — identical challenge, seed,
-// format, and content checksum. Builds matching on that tuple share images by
-// construction, so callers must not untag images while this returns true. On
-// a query error it fails safe (true): leaking an image tag is recoverable,
-// deleting one still in use is not.
+// resolves to the same docker tags as bMeta — identical challenge, seed, and
+// format, with bMeta's checksum as either its current generation or its
+// retained rollback generation (prevchecksum). Builds matching that way share
+// images by construction, so callers must not untag images while this returns
+// true. On a query error it fails safe (true): leaking an image tag is
+// recoverable, deleting one still in use is not.
 func (m *Manager) contentReferenced(bMeta *BuildMetadata, excludeBuild BuildId) bool {
 	var count int
 	err := m.db.Get(&count,
-		"SELECT COUNT(*) FROM builds WHERE challenge=? AND seed=? AND format=? AND checksum=? AND id != ?;",
-		bMeta.Challenge, bMeta.Seed, bMeta.Format, bMeta.Checksum, excludeBuild)
+		"SELECT COUNT(*) FROM builds WHERE challenge=? AND seed=? AND format=? AND (checksum=? OR prevchecksum=?) AND id != ?;",
+		bMeta.Challenge, bMeta.Seed, bMeta.Format, bMeta.Checksum, bMeta.Checksum, excludeBuild)
 	if err != nil {
 		m.log.errorf("failed to check for builds sharing image tags: %s", err)
 		return true

--- a/cmgr/database_builds.go
+++ b/cmgr/database_builds.go
@@ -38,13 +38,13 @@ func (m *Manager) openBuild(build *BuildMetadata) error {
 	}
 
 	m.log.debug("Running select...")
-	rows, err := m.db.NamedQuery("SELECT id, flag, hasartifacts, lastsolved FROM builds WHERE schema=:schema AND format=:format AND challenge=:challenge AND seed=:seed;", build)
+	rows, err := m.db.NamedQuery("SELECT id, flag, hasartifacts, lastsolved, checksum FROM builds WHERE schema=:schema AND format=:format AND challenge=:challenge AND seed=:seed;", build)
 	if err != nil {
 		m.log.errorf("failed to find build: %s", err)
 	} else if !rows.Next() {
 		m.log.error("found no rows when exactly one expected")
 	}
-	err = rows.Scan(&build.Id, &build.Flag, &build.HasArtifacts, &build.LastSolved)
+	err = rows.Scan(&build.Id, &build.Flag, &build.HasArtifacts, &build.LastSolved, &build.Checksum)
 	if err != nil {
 		m.log.errorf("failed to read build ID: %s", err)
 	}
@@ -62,6 +62,7 @@ const finalizeBuildQuery string = `
 	SET
 		flag = :flag,
 		hasartifacts = :hasartifacts,
+		checksum = :checksum,
 		lastsolved = 0
 	WHERE id = :id;`
 
@@ -189,6 +190,24 @@ func (m *Manager) finalizeBuild(build *BuildMetadata) error {
 	}
 
 	return err
+}
+
+// contentReferenced reports whether a build row other than excludeBuild
+// resolves to the same docker tags as bMeta — identical challenge, seed,
+// format, and content checksum. Builds matching on that tuple share images by
+// construction, so callers must not untag images while this returns true. On
+// a query error it fails safe (true): leaking an image tag is recoverable,
+// deleting one still in use is not.
+func (m *Manager) contentReferenced(bMeta *BuildMetadata, excludeBuild BuildId) bool {
+	var count int
+	err := m.db.Get(&count,
+		"SELECT COUNT(*) FROM builds WHERE challenge=? AND seed=? AND format=? AND checksum=? AND id != ?;",
+		bMeta.Challenge, bMeta.Seed, bMeta.Format, bMeta.Checksum, excludeBuild)
+	if err != nil {
+		m.log.errorf("failed to check for builds sharing image tags: %s", err)
+		return true
+	}
+	return count > 0
 }
 
 func (m *Manager) removeBuildMetadata(build BuildId) error {

--- a/cmgr/database_builds.go
+++ b/cmgr/database_builds.go
@@ -9,6 +9,7 @@ const openBuildQuery string = `
         flag,
         seed,
         format,
+        checksum,
         hasartifacts,
         lastsolved,
         challenge,
@@ -19,6 +20,7 @@ const openBuildQuery string = `
         :flag,
         :seed,
         :format,
+        :checksum,
         :hasartifacts,
         :lastsolved,
         :challenge,
@@ -29,6 +31,21 @@ const openBuildQuery string = `
     	instancecount = excluded.instancecount;`
 
 func (m *Manager) openBuild(build *BuildMetadata) error {
+	// Stamp the content checksum at creation so an in-flight build is already
+	// visible to the reference checks that guard image untagging (see
+	// contentReferenced): without it a new row sits at checksum=0 from creation
+	// until finalizeBuild, and a concurrent destroy/prune in that window would
+	// not count it as a reference and could remove images it resolves to. The
+	// value matches what executeBuild stamps before building. Best-effort: if
+	// the challenge's source checksum is unavailable the row keeps its incoming
+	// value (finalizeBuild still stamps the real one on success).
+	if build.Checksum == 0 {
+		var srcChecksum uint32
+		if err := m.db.Get(&srcChecksum, "SELECT sourcechecksum FROM challenges WHERE id = ?;", build.Challenge); err == nil {
+			build.Checksum = contentChecksum(srcChecksum, build.Format)
+		}
+	}
+
 	_, err := m.db.NamedExec(openBuildQuery, build)
 	m.log.debugf("Opening %v", build)
 
@@ -194,17 +211,21 @@ func (m *Manager) finalizeBuild(build *BuildMetadata) error {
 }
 
 // contentReferenced reports whether a build row other than excludeBuild
-// resolves to the same docker tags as bMeta — identical challenge, seed, and
-// format, with bMeta's checksum as either its current generation or its
-// retained rollback generation (prevchecksum). Builds matching that way share
-// images by construction, so callers must not untag images while this returns
-// true. On a query error it fails safe (true): leaking an image tag is
-// recoverable, deleting one still in use is not.
+// resolves to the same docker tags as bMeta. A tag is exactly
+// (challenge, seed, checksum, host) — see dockerId — so the key is challenge
+// and seed with bMeta's checksum as either the row's current generation or its
+// retained rollback generation (prevchecksum). Format is deliberately NOT in
+// the key: it affects a tag only through the checksum (see contentChecksum),
+// so two rows with different formats but an equal checksum genuinely share
+// images and must count as references — matching on format too would miss
+// them. Builds matching this way share images by construction, so callers must
+// not untag images while this returns true. On a query error it fails safe
+// (true): leaking an image tag is recoverable, deleting one still in use is not.
 func (m *Manager) contentReferenced(bMeta *BuildMetadata, excludeBuild BuildId) bool {
 	var count int
 	err := m.db.Get(&count,
-		"SELECT COUNT(*) FROM builds WHERE challenge=? AND seed=? AND format=? AND (checksum=? OR prevchecksum=?) AND id != ?;",
-		bMeta.Challenge, bMeta.Seed, bMeta.Format, bMeta.Checksum, bMeta.Checksum, excludeBuild)
+		"SELECT COUNT(*) FROM builds WHERE challenge=? AND seed=? AND (checksum=? OR prevchecksum=?) AND id != ?;",
+		bMeta.Challenge, bMeta.Seed, bMeta.Checksum, bMeta.Checksum, excludeBuild)
 	if err != nil {
 		m.log.errorf("failed to check for builds sharing image tags: %s", err)
 		return true

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -340,7 +340,7 @@ func (m *Manager) addChallenges(addedChallenges []*ChallengeMetadata) []error {
 	return errs
 }
 
-func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebuild bool) []error {
+func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebuild bool, pruneOldImages bool) []error {
 	errs := []error{}
 	for _, metadata := range updatedChallenges {
 		txn := m.db.MustBegin()
@@ -620,6 +620,7 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 				}
 				defer os.Remove(buildCtxFile)
 
+				replaced := []replacedImages{}
 				for _, buildId := range buildIds {
 					build, err := m.lookupBuildMetadata(buildId)
 					if err != nil {
@@ -632,12 +633,25 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 						continue
 					}
 
+					// Capture the retention pair before executeBuild stamps the
+					// new content checksum: the current generation becomes the
+					// retained rollback target (PrevChecksum) and the old
+					// rollback generation is displaced from retention.
+					oldChecksum := build.Checksum
+					displaced := build.PrevChecksum
+
 					// Resetting the flag signals to rebuild the Dockerfile
 					build.Flag = ""
 					err = m.executeBuild(metadata, build, buildCtxFile)
 					if err != nil {
 						errs = append(errs, err)
 						continue
+					}
+
+					// Rotate the retention pair; a rebuild that reproduced the
+					// same content leaves the rollback target untouched.
+					if build.Checksum != oldChecksum {
+						build.PrevChecksum = oldChecksum
 					}
 
 					// Update database
@@ -687,7 +701,34 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 							errs = append(errs, err)
 						}
 					}
+
+					// The displaced generation (two rebuilds back) leaves
+					// retention; the just-replaced one survives as the
+					// rollback target. Its tags are reconstructed over the
+					// current host set — a generation built with different
+					// hosts leaves strays for a future sweep to reclaim.
+					if pruneOldImages && build.Checksum != oldChecksum &&
+						displaced != 0 && displaced != build.Checksum {
+						displacedMeta := BuildMetadata{
+							Challenge: build.Challenge,
+							Seed:      build.Seed,
+							Format:    build.Format,
+							Checksum:  displaced,
+						}
+						tags := make([]string, 0, len(build.Images))
+						for _, image := range build.Images {
+							tags = append(tags, fmt.Sprintf("%s:%s", build.Challenge, displacedMeta.dockerId(image)))
+						}
+						replaced = append(replaced, replacedImages{tags: tags, meta: displacedMeta})
+					}
 				}
+
+				// Pruning waits until every build of this challenge has been
+				// processed: other rows can still hold the displaced checksum
+				// as their current or rollback generation until their own
+				// rebuild lands (or if it failed above) — contentReferenced
+				// keeps the images alive in all of those cases.
+				m.pruneReplacedImages(replaced)
 			}
 		}
 	}

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -340,6 +340,29 @@ func (m *Manager) addChallenges(addedChallenges []*ChallengeMetadata) []error {
 	return errs
 }
 
+// rotatedPrevChecksum returns the rollback generation to retain after a
+// rebuild. When the content changed (newChecksum != oldChecksum) the generation
+// just replaced (oldChecksum) becomes the new rollback target; otherwise the
+// existing target (currentPrev) is left untouched, so a no-op rebuild does not
+// disturb retention.
+func rotatedPrevChecksum(oldChecksum, newChecksum, currentPrev uint32) uint32 {
+	if newChecksum != oldChecksum {
+		return oldChecksum
+	}
+	return currentPrev
+}
+
+// displacedPruneCandidate reports whether a rebuild displaced an image
+// generation that '--prune-old' should untag: the content actually changed
+// (newChecksum != oldChecksum), there was a prior rollback generation to
+// displace (displaced != 0), and that displaced generation is not the same
+// content as the just-rebuilt one. The last clause guards an A->B->A
+// flip-flop, where the displaced generation equals the new current generation
+// and must therefore be kept, not pruned.
+func displacedPruneCandidate(oldChecksum, newChecksum, displaced uint32) bool {
+	return newChecksum != oldChecksum && displaced != 0 && displaced != newChecksum
+}
+
 func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebuild bool, pruneOldImages bool) []error {
 	errs := []error{}
 	for _, metadata := range updatedChallenges {
@@ -649,10 +672,14 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 					}
 
 					// Rotate the retention pair; a rebuild that reproduced the
-					// same content leaves the rollback target untouched.
-					if build.Checksum != oldChecksum {
-						build.PrevChecksum = oldChecksum
-					}
+					// same content checksum leaves the rollback target untouched.
+					// Caveat: a checksum-stable but content-changing rebuild (a
+					// challenge-type change, or a cmgr release with a different
+					// built-in Dockerfile — see contentChecksum) is not rotated,
+					// so its displaced image is left dangling rather than
+					// retained; that class falls outside the {current, previous}
+					// retention guarantee.
+					build.PrevChecksum = rotatedPrevChecksum(oldChecksum, build.Checksum, build.PrevChecksum)
 
 					// Update database
 					err = m.finalizeBuild(build)
@@ -707,8 +734,7 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 					// rollback target. Its tags are reconstructed over the
 					// current host set — a generation built with different
 					// hosts leaves strays for a future sweep to reclaim.
-					if pruneOldImages && build.Checksum != oldChecksum &&
-						displaced != 0 && displaced != build.Checksum {
+					if pruneOldImages && displacedPruneCandidate(oldChecksum, build.Checksum, displaced) {
 						displacedMeta := BuildMetadata{
 							Challenge: build.Challenge,
 							Seed:      build.Seed,

--- a/cmgr/database_operations_test.go
+++ b/cmgr/database_operations_test.go
@@ -1734,8 +1734,11 @@ func TestInitDatabaseRepairsStaleIsFinalizedDefault(t *testing.T) {
 	}
 	// Mirror the pre-rebuild schema: created_at present, is_finalized added with
 	// the legacy DEFAULT 1. Seed one already-launched instance (default 1).
+	// The builds stub carries the seed/format/challenge columns every real
+	// pre-checksum database has, so the builds.checksum migration's backfill
+	// query can run against it (its challenges join simply matches nothing).
 	legacy := `
-	CREATE TABLE builds (id INTEGER PRIMARY KEY, schema TEXT);
+	CREATE TABLE builds (id INTEGER PRIMARY KEY, schema TEXT, seed INTEGER, format TEXT, challenge TEXT);
 	CREATE TABLE instances (
 		id INTEGER PRIMARY KEY,
 		lastsolved INTEGER,

--- a/cmgr/database_operations_test.go
+++ b/cmgr/database_operations_test.go
@@ -169,7 +169,7 @@ func TestDatabaseUpdateChallenge(t *testing.T) {
 	challenge.Tags = []string{"updated", "modified"}
 	challenge.Attributes = map[string]string{"version": "2", "status": "active"}
 
-	errs = mgr.updateChallenges([]*ChallengeMetadata{challenge}, false)
+	errs = mgr.updateChallenges([]*ChallengeMetadata{challenge}, false, false)
 	if len(errs) > 0 {
 		t.Fatalf("updateChallenges failed: %v", errs)
 	}

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -307,7 +307,18 @@ func contentChecksum(sourceChecksum uint32, format string) uint32 {
 	binary.BigEndian.PutUint32(src[:], sourceChecksum)
 	h.Write(src[:])
 	h.Write([]byte(format))
-	return h.Sum32()
+	sum := h.Sum32()
+	// 0 is reserved as the "unset / not-yet-migrated" sentinel: builds.checksum
+	// and prevchecksum default to 0, the migration backfill keys on checksum=0,
+	// and prevchecksum=0 means "no rollback generation". CRC-32 can legitimately
+	// be 0 (e.g. sourceChecksum 0x05f16712 with format "flag{%s}"), which would
+	// make a real generation indistinguishable from "none", so map that single
+	// value to 1. This adds only the same negligible collision the CRC already
+	// permits.
+	if sum == 0 {
+		sum = 1
+	}
+	return sum
 }
 
 // dockerId is the docker tag for one of the build's images. It is derived

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -165,9 +165,6 @@ func (m *Manager) generateBuilds(builds []*BuildMetadata) error {
 	for _, build := range builds {
 		buildsComplete = buildsComplete && (build.Flag != "")
 	}
-	if buildsComplete {
-		return nil
-	}
 
 	cMeta, err := m.lookupChallengeMetadata(builds[0].Challenge)
 	if err != nil {
@@ -175,12 +172,6 @@ func (m *Manager) generateBuilds(builds []*BuildMetadata) error {
 	}
 
 	updates := m.DetectChanges(filepath.Dir(cMeta.Path))
-	if len(updates.Errors) > 0 {
-		err = fmt.Errorf("errors detected in directory for '%s' run 'update'", cMeta.Id)
-		m.log.error(err)
-		return err
-	}
-
 	modified := true
 	for _, md := range updates.Unmodified {
 		if md.Id == cMeta.Id {
@@ -188,6 +179,25 @@ func (m *Manager) generateBuilds(builds []*BuildMetadata) error {
 			break
 		}
 	}
+
+	if buildsComplete {
+		// Nothing to build, but surface drift instead of returning silently:
+		// converging a schema does not rebuild existing builds — only
+		// 'update' does — so without this the images would quietly go stale.
+		if len(updates.Errors) > 0 {
+			m.log.warnf("errors detected in directory for '%s'; run 'update': %v", cMeta.Id, updates.Errors)
+		} else if modified {
+			m.log.warnf("source for '%s' has changed since last update; existing builds and images are stale until 'update' is run", cMeta.Id)
+		}
+		return nil
+	}
+
+	if len(updates.Errors) > 0 {
+		err = fmt.Errorf("errors detected in directory for '%s' run 'update'", cMeta.Id)
+		m.log.error(err)
+		return err
+	}
+
 	if modified {
 		err = fmt.Errorf("'%s' has changed since last update", cMeta.Id)
 		m.log.error(err)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -7,9 +7,11 @@ import (
 	"crypto/sha256"
 	_ "embed"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"io/ioutil"
 	"net/netip"
@@ -23,6 +25,7 @@ import (
 	"github.com/containerd/errdefs"
 	dockeropts "github.com/docker/cli/opts"
 	"github.com/docker/go-units"
+	"github.com/jmoiron/sqlx"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/strslice"
@@ -260,8 +263,85 @@ func dockerStreamError(messages []byte) error {
 	return errors.New(string(errMsg))
 }
 
+// contentChecksum derives the content identity of a build's images: the
+// challenge source checksum combined with the flag format, which both bake
+// into the images via build args. The seed also affects image content but is
+// carried explicitly in the docker tag, so it is not folded in here.
+func contentChecksum(sourceChecksum uint32, format string) uint32 {
+	h := crc32.NewIEEE()
+	var src [4]byte
+	binary.BigEndian.PutUint32(src[:], sourceChecksum)
+	h.Write(src[:])
+	h.Write([]byte(format))
+	return h.Sum32()
+}
+
+// dockerId is the docker tag for one of the build's images. It is derived
+// from portable build identity — seed plus content checksum — rather than the
+// local autoincrement build id, so the same challenge content yields the same
+// tag no matter which cmgr database built it, and a source change yields a
+// new tag instead of mutating the old one. The "s" prefix keeps the tag valid
+// when the seed is negative.
 func (bMeta *BuildMetadata) dockerId(image Image) string {
-	return fmt.Sprintf("%d-%s", bMeta.Id, image.Host)
+	return fmt.Sprintf("s%d-%x-%s", bMeta.Seed, bMeta.Checksum, image.Host)
+}
+
+// migrateBuildChecksums backfills builds.checksum for rows created before the
+// column existed and retags their local docker images from the legacy
+// {buildid}-{host} tag form to the content-addressed form (see dockerId).
+// The backfill derives each build's checksum from its challenge's current
+// source checksum, which is what the images were built from as of the last
+// update — the same assumption the pre-checksum code made when it reused a
+// tag across rebuilds. Called from initDatabase before m.db is assigned, so
+// the handle is passed in explicitly; m.cli is nil when the database is
+// initialized without docker (tests), in which case retagging is skipped.
+func (m *Manager) migrateBuildChecksums(db *sqlx.DB) error {
+	rows := []struct {
+		Id             BuildId
+		Seed           int
+		Format         string
+		Challenge      string
+		SourceChecksum uint32 `db:"sourcechecksum"`
+	}{}
+	err := db.Select(&rows, `SELECT b.id, b.seed, b.format, b.challenge, c.sourcechecksum
+		FROM builds AS b JOIN challenges AS c ON b.challenge = c.id;`)
+	if err != nil {
+		return err
+	}
+
+	for _, row := range rows {
+		checksum := contentChecksum(row.SourceChecksum, row.Format)
+		if _, err := db.Exec("UPDATE builds SET checksum = ? WHERE id = ?;", checksum, row.Id); err != nil {
+			return err
+		}
+
+		if m.cli == nil {
+			continue
+		}
+
+		hosts := []string{}
+		if err := db.Select(&hosts, "SELECT host FROM images WHERE build = ?;", row.Id); err != nil {
+			return err
+		}
+		newMeta := BuildMetadata{Seed: row.Seed, Checksum: checksum}
+		for _, host := range hosts {
+			oldRef := fmt.Sprintf("%s:%d-%s", row.Challenge, row.Id, host)
+			newRef := fmt.Sprintf("%s:%s", row.Challenge, newMeta.dockerId(Image{Host: host}))
+			if _, err := m.cli.ImageTag(m.ctx, client.ImageTagOptions{Source: oldRef, Target: newRef}); err != nil {
+				// The image may simply not exist locally (already removed
+				// out-of-band, or a fresh daemon); the next rebuild recreates
+				// it under the new name, so this is not fatal.
+				m.log.warnf("could not retag legacy image %s as %s: %s", oldRef, newRef, err)
+				continue
+			}
+			// Drop the legacy ref; the image survives under the new one.
+			if _, err := m.cli.ImageRemove(m.ctx, oldRef, client.ImageRemoveOptions{Force: false, PruneChildren: false}); err != nil {
+				m.log.warnf("could not remove legacy image tag %s: %s", oldRef, err)
+			}
+			m.log.infof("retagged image %s as %s", oldRef, newRef)
+		}
+	}
+	return nil
 }
 
 func challengeToFreezeName(challenge ChallengeId) string {
@@ -300,6 +380,10 @@ func (m *Manager) freezeBaseImage(challenge ChallengeId, force bool) error {
 		Target:     "base",
 		NoCache:    force, // Require to use latest info on force
 		PullParent: force, // Update parent image as well on force
+		Labels: map[string]string{
+			"cmgr.managed":   "true",
+			"cmgr.challenge": string(challenge),
+		},
 	}
 
 	// Build the image
@@ -355,6 +439,10 @@ func (m *Manager) executeBuild(cMeta *ChallengeMetadata, bMeta *BuildMetadata, b
 
 	seedStr := fmt.Sprintf("%d", bMeta.Seed)
 
+	// Stamp the build with the content identity its images are about to be
+	// produced from; dockerId (and therefore every tag below) depends on it.
+	bMeta.Checksum = contentChecksum(cMeta.SourceChecksum, bMeta.Format)
+
 	baseName := fmt.Sprintf("%s/%s:%x", m.challengeRegistry, challengeToFreezeName(cMeta.Id), cMeta.SourceChecksum)
 	pullOpts := client.ImagePullOptions{RegistryAuth: m.authString}
 	var buildCache []string
@@ -399,6 +487,10 @@ func (m *Manager) executeBuild(cMeta *ChallengeMetadata, bMeta *BuildMetadata, b
 			CacheFrom: buildCache,
 			Tags:      []string{imageName},
 			Target:    host.Target,
+			Labels: map[string]string{
+				"cmgr.managed":   "true",
+				"cmgr.challenge": string(cMeta.Id),
+			},
 		}
 
 		// Call build
@@ -594,10 +686,15 @@ func (m *Manager) executeBuild(cMeta *ChallengeMetadata, bMeta *BuildMetadata, b
 	if err != nil {
 		os.Remove(bMeta.getArtifactsFilename())
 
-		iro := client.ImageRemoveOptions{Force: false, PruneChildren: true}
-		for _, image := range bMeta.Images {
-			imageName := fmt.Sprintf("%s:%s", bMeta.Challenge, bMeta.dockerId(image))
-			_, _ = m.cli.ImageRemove(m.ctx, imageName, iro)
+		// Content-addressed tags are shared by every build row with the same
+		// (challenge, seed, format, checksum) tuple — e.g. the same challenge
+		// and seed in two schemas — so only untag when no other row needs them.
+		if !m.contentReferenced(bMeta, bMeta.Id) {
+			iro := client.ImageRemoveOptions{Force: false, PruneChildren: true}
+			for _, image := range bMeta.Images {
+				imageName := fmt.Sprintf("%s:%s", bMeta.Challenge, bMeta.dockerId(image))
+				_, _ = m.cli.ImageRemove(m.ctx, imageName, iro)
+			}
 		}
 	}
 
@@ -923,6 +1020,15 @@ func (m *Manager) destroyImages(build BuildId) error {
 				return err
 			}
 		}
+	}
+
+	// The build's metadata row is already gone, so any remaining row with the
+	// same (challenge, seed, format, checksum) tuple is another build that
+	// shares these exact tags (e.g. the same challenge and seed in two
+	// schemas); in that case the images must survive.
+	if m.contentReferenced(bMeta, bMeta.Id) {
+		m.log.debugf("keeping images for destroyed build %d: content still referenced by another build", build)
+		return nil
 	}
 
 	iro := client.ImageRemoveOptions{Force: true, PruneChildren: true}

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -174,23 +174,45 @@ func (m *Manager) generateBuilds(builds []*BuildMetadata) error {
 		return err
 	}
 
+	// Note: DetectChanges re-parses and re-hashes the challenge directory on
+	// every converge, even when all builds are already complete (below). That
+	// cost is inherent to detecting drift here; it is paid per challenge on each
+	// CreateSchema/UpdateSchema (e.g. cmgrd instance-count resizes). If it
+	// becomes a bottleneck for large schemas, compare only this challenge's
+	// stored SourceChecksum instead of running a full cross-schema DetectChanges.
 	updates := m.DetectChanges(filepath.Dir(cMeta.Path))
-	modified := true
-	for _, md := range updates.Unmodified {
-		if md.Id == cMeta.Id {
-			modified = false
-			break
+
+	inList := func(list []*ChallengeMetadata) bool {
+		for _, md := range list {
+			if md.Id == cMeta.Id {
+				return true
+			}
 		}
+		return false
 	}
+	// The buckets are distinct: only Updated implies changed image content (and
+	// hence stale images); Refreshed is a metadata/solve-script change with the
+	// source checksum unchanged, so its images are current. modified drives the
+	// pending-build error path below (anything not Unmodified is drift).
+	sourceChanged := inList(updates.Updated)
+	metadataChanged := inList(updates.Refreshed)
+	removed := inList(updates.Removed)
+	modified := sourceChanged || metadataChanged || removed
 
 	if buildsComplete {
 		// Nothing to build, but surface drift instead of returning silently:
-		// converging a schema does not rebuild existing builds — only
-		// 'update' does — so without this the images would quietly go stale.
-		if len(updates.Errors) > 0 {
+		// converging a schema neither rebuilds nor refreshes existing builds —
+		// only 'update' does — so name whatever 'update' would act on, without
+		// overstating staleness for a metadata-only change.
+		switch {
+		case len(updates.Errors) > 0:
 			m.log.warnf("errors detected in directory for '%s'; run 'update': %v", cMeta.Id, updates.Errors)
-		} else if modified {
+		case sourceChanged:
 			m.log.warnf("source for '%s' has changed since last update; existing builds and images are stale until 'update' is run", cMeta.Id)
+		case metadataChanged:
+			m.log.warnf("metadata for '%s' has changed since last update; run 'update' to refresh it (images are unaffected)", cMeta.Id)
+		case removed:
+			m.log.warnf("source for '%s' can no longer be found; its existing builds are stale", cMeta.Id)
 		}
 		return nil
 	}
@@ -263,10 +285,22 @@ func dockerStreamError(messages []byte) error {
 	return errors.New(string(errMsg))
 }
 
-// contentChecksum derives the content identity of a build's images: the
-// challenge source checksum combined with the flag format, which both bake
-// into the images via build args. The seed also affects image content but is
+// contentChecksum derives the content identity of a build's images from the
+// challenge source checksum and the flag format. The source content reaches
+// the image through the build context (and the frozen base image); the flag
+// format enters as a build arg. The seed also affects image content but is
 // carried explicitly in the docker tag, so it is not folded in here.
+//
+// Caveat: the embedded per-type Dockerfile (m.GetDockerfile) is part of the
+// build context but NOT part of this checksum. So a rebuild whose only change
+// is the challenge type, or a cmgr release shipping a different built-in
+// Dockerfile (e.g. a base-image bump), yields different image content under an
+// unchanged tag. Within one database this is just the tag reuse the scheme
+// already tolerates; across databases sharing a daemon it means identical
+// tuples can resolve to differing content. Folding the type Dockerfile (or a
+// build-machinery version) in here would close that, but the migration
+// backfill cannot reconstruct a legacy row's historical Dockerfile, so it is
+// deferred.
 func contentChecksum(sourceChecksum uint32, format string) uint32 {
 	h := crc32.NewIEEE()
 	var src [4]byte
@@ -286,15 +320,20 @@ func (bMeta *BuildMetadata) dockerId(image Image) string {
 	return fmt.Sprintf("s%d-%x-%s", bMeta.Seed, bMeta.Checksum, image.Host)
 }
 
-// migrateBuildChecksums backfills builds.checksum for rows created before the
-// column existed and retags their local docker images from the legacy
-// {buildid}-{host} tag form to the content-addressed form (see dockerId).
-// The backfill derives each build's checksum from its challenge's current
-// source checksum, which is what the images were built from as of the last
-// update — the same assumption the pre-checksum code made when it reused a
-// tag across rebuilds. Called from initDatabase before m.db is assigned, so
-// the handle is passed in explicitly; m.cli is nil when the database is
-// initialized without docker (tests), in which case retagging is skipped.
+// migrateBuildChecksums backfills builds.checksum for rows still at the default
+// value (0) and retags their local docker images from the legacy {buildid}-{host}
+// tag form to the content-addressed form (see dockerId). The backfill derives
+// each build's checksum from its challenge's current source checksum, which is
+// what the images were built from as of the last update — the same assumption
+// the pre-checksum code made when it reused a tag across rebuilds.
+//
+// It is resumable and idempotent: the work is keyed on checksum=0 (the
+// "not yet migrated" marker) rather than on the column's existence, and each
+// row's images are retagged BEFORE its checksum is stamped, so an interruption
+// or transient docker error leaves the row at 0 to be retried on the next
+// start. Called from initDatabase before m.db is assigned, so the handle is
+// passed in explicitly; m.cli is nil when the database is initialized without
+// docker (tests), in which case retagging is skipped.
 func (m *Manager) migrateBuildChecksums(db *sqlx.DB) error {
 	rows := []struct {
 		Id             BuildId
@@ -304,42 +343,81 @@ func (m *Manager) migrateBuildChecksums(db *sqlx.DB) error {
 		SourceChecksum uint32 `db:"sourcechecksum"`
 	}{}
 	err := db.Select(&rows, `SELECT b.id, b.seed, b.format, b.challenge, c.sourcechecksum
-		FROM builds AS b JOIN challenges AS c ON b.challenge = c.id;`)
+		FROM builds AS b JOIN challenges AS c ON b.challenge = c.id
+		WHERE b.checksum = 0;`)
 	if err != nil {
 		return err
 	}
 
 	for _, row := range rows {
 		checksum := contentChecksum(row.SourceChecksum, row.Format)
+
+		// Retag first: checksum=0 is the resume marker, so it is stamped only
+		// once the images provably carry the new tag (or are shown to need no
+		// retag). A genuine docker error aborts, leaving the row at 0.
+		if err := m.retagLegacyImages(db, row.Id, row.Challenge, row.Seed, checksum); err != nil {
+			return err
+		}
+
 		if _, err := db.Exec("UPDATE builds SET checksum = ? WHERE id = ?;", checksum, row.Id); err != nil {
 			return err
 		}
+	}
 
-		if m.cli == nil {
+	// Rows that never joined a challenge (e.g. out-of-band DB edits with foreign
+	// keys off) stay at checksum=0 and would yield an invalid s{seed}-0 tag;
+	// surface them rather than failing silently at launch time.
+	var unmigrated int
+	if err := db.Get(&unmigrated, "SELECT COUNT(1) FROM builds WHERE checksum = 0;"); err != nil {
+		return err
+	}
+	if unmigrated > 0 {
+		m.log.warnf("%d build(s) have no content checksum (missing challenge row?); their images cannot be resolved until the challenge is rebuilt", unmigrated)
+	}
+
+	return nil
+}
+
+// retagLegacyImages moves a build's images from the legacy {challenge}:{id}-{host}
+// tag form to the content-addressed {challenge}:s{seed}-{checksum}-{host} form.
+// It is idempotent and tolerant of a missing source image (already retagged on
+// a prior interrupted run, or a fresh daemon that will rebuild on demand): only
+// a genuine daemon error is returned, so migrateBuildChecksums can defer
+// stamping the checksum until the retag has succeeded or been shown
+// unnecessary. Skipped without a docker client (tests).
+func (m *Manager) retagLegacyImages(db *sqlx.DB, id BuildId, challenge string, seed int, checksum uint32) error {
+	if m.cli == nil {
+		return nil
+	}
+
+	hosts := []string{}
+	if err := db.Select(&hosts, "SELECT host FROM images WHERE build = ?;", id); err != nil {
+		return err
+	}
+
+	newMeta := BuildMetadata{Seed: seed, Checksum: checksum}
+	for _, host := range hosts {
+		oldRef := fmt.Sprintf("%s:%d-%s", challenge, id, host)
+		newRef := fmt.Sprintf("%s:%s", challenge, newMeta.dockerId(Image{Host: host}))
+
+		if _, err := m.cli.ImageTag(m.ctx, client.ImageTagOptions{Source: oldRef, Target: newRef}); err != nil {
+			if !errdefs.IsNotFound(err) {
+				// A real daemon error, not a missing image: abort so the row
+				// stays at checksum=0 and the retag is retried next start.
+				return fmt.Errorf("could not retag legacy image %s as %s: %w", oldRef, newRef, err)
+			}
+			// Source absent: either already retagged (new ref present) or never
+			// present locally (fresh daemon / pruned out-of-band). Nothing to
+			// recover; the next rebuild recreates it under the new name.
+			m.log.debugf("legacy image %s not present; skipping retag", oldRef)
 			continue
 		}
-
-		hosts := []string{}
-		if err := db.Select(&hosts, "SELECT host FROM images WHERE build = ?;", row.Id); err != nil {
-			return err
+		// Drop the legacy ref; the image survives under the new one. A missing
+		// legacy tag here is fine (idempotent re-run after a prior removal).
+		if _, err := m.cli.ImageRemove(m.ctx, oldRef, client.ImageRemoveOptions{Force: false, PruneChildren: false}); err != nil && !errdefs.IsNotFound(err) {
+			m.log.warnf("could not remove legacy image tag %s: %s", oldRef, err)
 		}
-		newMeta := BuildMetadata{Seed: row.Seed, Checksum: checksum}
-		for _, host := range hosts {
-			oldRef := fmt.Sprintf("%s:%d-%s", row.Challenge, row.Id, host)
-			newRef := fmt.Sprintf("%s:%s", row.Challenge, newMeta.dockerId(Image{Host: host}))
-			if _, err := m.cli.ImageTag(m.ctx, client.ImageTagOptions{Source: oldRef, Target: newRef}); err != nil {
-				// The image may simply not exist locally (already removed
-				// out-of-band, or a fresh daemon); the next rebuild recreates
-				// it under the new name, so this is not fatal.
-				m.log.warnf("could not retag legacy image %s as %s: %s", oldRef, newRef, err)
-				continue
-			}
-			// Drop the legacy ref; the image survives under the new one.
-			if _, err := m.cli.ImageRemove(m.ctx, oldRef, client.ImageRemoveOptions{Force: false, PruneChildren: false}); err != nil {
-				m.log.warnf("could not remove legacy image tag %s: %s", oldRef, err)
-			}
-			m.log.infof("retagged image %s as %s", oldRef, newRef)
-		}
+		m.log.infof("retagged image %s as %s", oldRef, newRef)
 	}
 	return nil
 }
@@ -689,16 +767,29 @@ func (m *Manager) executeBuild(cMeta *ChallengeMetadata, bMeta *BuildMetadata, b
 	if err != nil {
 		os.Remove(bMeta.getArtifactsFilename())
 
-		// Content-addressed tags are shared by every build row with the same
-		// (challenge, seed, format, checksum) tuple — e.g. the same challenge
-		// and seed in two schemas — so only untag when no other row needs them.
-		if !m.contentReferenced(bMeta, bMeta.Id) {
+		// Free the build image now rather than waiting for the deferred
+		// container cleanup: while the extraction container exists it references
+		// the image, so the non-forced ImageRemove below could not untag it.
+		// (The deferred removal then no-ops on the already-gone container.)
+		_, _ = m.cli.ContainerRemove(m.ctx, cid, crOpts)
+
+		// Untag the failed generation's images unless they must survive: another
+		// build row may share this exact (challenge, seed, format, checksum)
+		// tuple (e.g. the same challenge and seed in two schemas), or THIS row —
+		// on the rebuild path, not yet finalized — may retain this checksum as
+		// its rollback target (PrevChecksum), as after an A->B->A source revert.
+		// Both cases keep the images; only a genuinely unreferenced failed
+		// generation is removed. imageMu keeps the check-and-remove atomic
+		// against concurrent removers (destroyImages/pruneReplacedImages).
+		m.imageMu.Lock()
+		if bMeta.PrevChecksum != bMeta.Checksum && !m.contentReferenced(bMeta, bMeta.Id) {
 			iro := client.ImageRemoveOptions{Force: false, PruneChildren: true}
 			for _, image := range bMeta.Images {
 				imageName := fmt.Sprintf("%s:%s", bMeta.Challenge, bMeta.dockerId(image))
 				_, _ = m.cli.ImageRemove(m.ctx, imageName, iro)
 			}
 		}
+		m.imageMu.Unlock()
 	}
 
 	m.log.debugf("%v", bMeta)
@@ -1013,6 +1104,13 @@ type replacedImages struct {
 // removal failures are logged but never fatal — a leaked tag is recoverable,
 // a failed update is not.
 func (m *Manager) pruneReplacedImages(replaced []replacedImages) {
+	// Serialize the reference-check-then-remove against concurrent removers
+	// (destroyImages, executeBuild cleanup): content-addressed tags are shared
+	// across build rows, so an unsynchronized check could untag images a build
+	// finalized between the check and the removal.
+	m.imageMu.Lock()
+	defer m.imageMu.Unlock()
+
 	iro := client.ImageRemoveOptions{Force: false, PruneChildren: true}
 	for _, r := range replaced {
 		if m.contentReferenced(&r.meta, 0) {
@@ -1066,20 +1164,29 @@ func (m *Manager) destroyImages(build BuildId) error {
 	// shares these exact tags (e.g. the same challenge and seed in two
 	// schemas); in that case the images must survive. The current and rollback
 	// generations are checked independently — either can outlive the other.
-	iro := client.ImageRemoveOptions{Force: true, PruneChildren: true}
+	//
+	// Force is false and removal failures are non-fatal by design: a content
+	// tag can be referenced outside this cmgr database — another cmgr instance
+	// on the same daemon that built identical content, possibly with a running
+	// or stopped container this database cannot see. Refusing to delete an
+	// in-use image and leaking the tag is recoverable; force-removing it out
+	// from under another instance is not. This mirrors the opt-in rationale for
+	// 'update --prune-old' (see UpdateOptions.PruneOldImages). imageMu serializes
+	// the reference-check-then-remove against concurrent removers.
+	m.imageMu.Lock()
+	defer m.imageMu.Unlock()
+
+	iro := client.ImageRemoveOptions{Force: false, PruneChildren: true}
 	if m.contentReferenced(bMeta, bMeta.Id) {
 		m.log.debugf("keeping images for destroyed build %d: content still referenced by another build", build)
 	} else {
 		for _, image := range bMeta.Images {
-
 			imageName := fmt.Sprintf("%s:%s", bMeta.Challenge, bMeta.dockerId(image))
-			_, err := m.cli.ImageRemove(m.ctx, imageName, iro)
-			if err != nil {
+			if _, err := m.cli.ImageRemove(m.ctx, imageName, iro); err != nil {
 				if errdefs.IsNotFound(err) {
 					m.log.warnf("skipped removing image (not found): %s", imageName)
 				} else {
-					m.log.errorf("failed to remove image: %s", err)
-					return err
+					m.log.warnf("could not remove image %s (leaving it in place): %s", imageName, err)
 				}
 			}
 		}

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -533,6 +533,9 @@ func (m *Manager) executeBuild(cMeta *ChallengeMetadata, bMeta *BuildMetadata, b
 	// image; it is never started. Override the command so creation succeeds even
 	// for images with no CMD/ENTRYPOINT (e.g. artifact-only custom Dockerfiles),
 	// which Docker otherwise rejects with "no command specified".
+	// NOTE: a future `rollback` would re-run everything from here down against
+	// the PrevChecksum image (no docker build) to restore that generation's
+	// artifacts, lookups, and DB state.
 	cConfig := container.Config{Image: buildImage, Cmd: []string{"true"}}
 	hConfig := container.HostConfig{}
 	nConfig := network.NetworkingConfig{}
@@ -996,6 +999,42 @@ func (m *Manager) stopContainers(instance *InstanceMetadata) error {
 	return err
 }
 
+// replacedImages records the docker tags of a build generation superseded by
+// a rebuild, along with the identity tuple those tags encode.
+type replacedImages struct {
+	tags []string
+	meta BuildMetadata
+}
+
+// pruneReplacedImages untags image generations that fell out of retention
+// after an update rebuild (the 'update --prune-old' flow): the generation
+// displaced from PrevChecksum, never the newly retained rollback target. Each
+// entry is skipped while any live build row still resolves to its tuple;
+// removal failures are logged but never fatal — a leaked tag is recoverable,
+// a failed update is not.
+func (m *Manager) pruneReplacedImages(replaced []replacedImages) {
+	iro := client.ImageRemoveOptions{Force: false, PruneChildren: true}
+	for _, r := range replaced {
+		if m.contentReferenced(&r.meta, 0) {
+			m.log.debugf("keeping replaced images for %s: content still referenced by another build", r.meta.Challenge)
+			continue
+		}
+		for _, tag := range r.tags {
+			if _, err := m.cli.ImageRemove(m.ctx, tag, iro); err != nil {
+				if errdefs.IsNotFound(err) {
+					// Already removed — e.g. a build in another schema shared
+					// the tuple and its entry was pruned first.
+					m.log.debugf("replaced image already gone: %s", tag)
+				} else {
+					m.log.warnf("could not prune replaced image %s: %s", tag, err)
+				}
+			} else {
+				m.log.infof("pruned replaced image %s", tag)
+			}
+		}
+	}
+}
+
 func (m *Manager) destroyImages(build BuildId) error {
 	m.log.debugf("destroying build %d", build)
 	bMeta, err := m.lookupBuildMetadata(build)
@@ -1022,26 +1061,46 @@ func (m *Manager) destroyImages(build BuildId) error {
 		}
 	}
 
-	// The build's metadata row is already gone, so any remaining row with the
-	// same (challenge, seed, format, checksum) tuple is another build that
+	// The build's metadata row is already gone, so any remaining row holding
+	// this content as its current or rollback generation is another build that
 	// shares these exact tags (e.g. the same challenge and seed in two
-	// schemas); in that case the images must survive.
+	// schemas); in that case the images must survive. The current and rollback
+	// generations are checked independently — either can outlive the other.
+	iro := client.ImageRemoveOptions{Force: true, PruneChildren: true}
 	if m.contentReferenced(bMeta, bMeta.Id) {
 		m.log.debugf("keeping images for destroyed build %d: content still referenced by another build", build)
-		return nil
+	} else {
+		for _, image := range bMeta.Images {
+
+			imageName := fmt.Sprintf("%s:%s", bMeta.Challenge, bMeta.dockerId(image))
+			_, err := m.cli.ImageRemove(m.ctx, imageName, iro)
+			if err != nil {
+				if errdefs.IsNotFound(err) {
+					m.log.warnf("skipped removing image (not found): %s", imageName)
+				} else {
+					m.log.errorf("failed to remove image: %s", err)
+					return err
+				}
+			}
+		}
 	}
 
-	iro := client.ImageRemoveOptions{Force: true, PruneChildren: true}
-	for _, image := range bMeta.Images {
-
-		imageName := fmt.Sprintf("%s:%s", bMeta.Challenge, bMeta.dockerId(image))
-		_, err := m.cli.ImageRemove(m.ctx, imageName, iro)
-		if err != nil {
-			if errdefs.IsNotFound(err) {
-				m.log.warnf("skipped removing image (not found): %s", imageName)
-			} else {
-				m.log.errorf("failed to remove image: %s", err)
-				return err
+	// Retire the build's retained rollback generation the same way; its tags
+	// may already be gone (never rotated, or pruned via another row), so
+	// removal here is best-effort.
+	if bMeta.PrevChecksum != 0 && bMeta.PrevChecksum != bMeta.Checksum {
+		prevMeta := BuildMetadata{
+			Challenge: bMeta.Challenge,
+			Seed:      bMeta.Seed,
+			Format:    bMeta.Format,
+			Checksum:  bMeta.PrevChecksum,
+		}
+		if !m.contentReferenced(&prevMeta, bMeta.Id) {
+			for _, image := range bMeta.Images {
+				imageName := fmt.Sprintf("%s:%s", bMeta.Challenge, prevMeta.dockerId(image))
+				if _, err := m.cli.ImageRemove(m.ctx, imageName, iro); err != nil && !errdefs.IsNotFound(err) {
+					m.log.warnf("could not remove rollback-generation image %s: %s", imageName, err)
+				}
 			}
 		}
 	}

--- a/cmgr/retention_test.go
+++ b/cmgr/retention_test.go
@@ -2,6 +2,17 @@ package cmgr
 
 import "testing"
 
+// TestContentChecksumNeverZero pins the reservation of 0 as the "unset"
+// sentinel. sourceChecksum 0x05f16712 with format "flag{%s}" is a concrete
+// input whose raw CRC-32 is exactly 0x00000000, so without the reservation a
+// real generation would be indistinguishable from "none" (default 0, the
+// migration's checksum=0 marker, and prevchecksum=0 meaning no rollback gen).
+func TestContentChecksumNeverZero(t *testing.T) {
+	if got := contentChecksum(0x05f16712, "flag{%s}"); got == 0 {
+		t.Fatal("contentChecksum returned 0 for a known CRC-32-zero input; 0 must be reserved as the unset sentinel")
+	}
+}
+
 // TestRotatedPrevChecksum pins the retention rotation: the just-replaced
 // generation becomes the rollback target when content changes, and an
 // unchanged rebuild leaves the existing target alone.

--- a/cmgr/retention_test.go
+++ b/cmgr/retention_test.go
@@ -1,0 +1,220 @@
+package cmgr
+
+import "testing"
+
+// TestRotatedPrevChecksum pins the retention rotation: the just-replaced
+// generation becomes the rollback target when content changes, and an
+// unchanged rebuild leaves the existing target alone.
+func TestRotatedPrevChecksum(t *testing.T) {
+	cases := []struct {
+		name                          string
+		oldChecksum, newChecksum, cur uint32
+		want                          uint32
+	}{
+		{"content changed retains replaced generation", 0xA, 0xB, 0x9, 0xA},
+		{"unchanged rebuild leaves target untouched", 0xA, 0xA, 0x9, 0x9},
+		{"first build has no rollback target", 0, 0xB, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rotatedPrevChecksum(tc.oldChecksum, tc.newChecksum, tc.cur); got != tc.want {
+				t.Errorf("rotatedPrevChecksum(%#x,%#x,%#x) = %#x, want %#x",
+					tc.oldChecksum, tc.newChecksum, tc.cur, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDisplacedPruneCandidate pins the --prune-old guard, including the
+// A->B->A flip-flop case where the displaced generation equals the just-rebuilt
+// current one and must NOT be pruned.
+func TestDisplacedPruneCandidate(t *testing.T) {
+	cases := []struct {
+		name                            string
+		oldChecksum, newChecksum, displ uint32
+		want                            bool
+	}{
+		{"normal displacement is a candidate", 0xB, 0xC, 0xA, true},
+		{"no content change is not a candidate", 0xB, 0xB, 0xA, false},
+		{"nothing displaced is not a candidate", 0xB, 0xC, 0, false},
+		{"flip-flop keeps the current generation", 0xB, 0xA, 0xA, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := displacedPruneCandidate(tc.oldChecksum, tc.newChecksum, tc.displ); got != tc.want {
+				t.Errorf("displacedPruneCandidate(%#x,%#x,%#x) = %v, want %v",
+					tc.oldChecksum, tc.newChecksum, tc.displ, got, tc.want)
+			}
+		})
+	}
+}
+
+// retentionTestChallenge returns a minimal custom challenge with a known source
+// checksum, suitable for openBuild/finalizeBuild and the migration backfill.
+func retentionTestChallenge(id ChallengeId, sourceChecksum uint32) *ChallengeMetadata {
+	return &ChallengeMetadata{
+		Id:             id,
+		Name:           "Retention",
+		Namespace:      "test",
+		ChallengeType:  "custom",
+		SourceChecksum: sourceChecksum,
+		Path:           "/tmp/test/problem.md",
+		Hosts:          []HostInfo{{Name: "challenge", Target: ""}},
+		PortMap:        map[string]PortInfo{},
+	}
+}
+
+// TestFinalizeBuildPersistsChecksums guards the durable half of the rotation
+// contract: finalizeBuild must write both checksum and prevchecksum, so the
+// refcount guard (which reads them back) sees the true generation pair. If the
+// SET clauses were dropped, the round-tripped values would be wrong.
+func TestFinalizeBuildPersistsChecksums(t *testing.T) {
+	mgr := setupTestManager(t)
+	defer mgr.db.Close()
+
+	const format = "flag{%s}"
+	challenge := retentionTestChallenge("test/finalize-checksums", 0x11112222)
+	if errs := mgr.addChallenges([]*ChallengeMetadata{challenge}); len(errs) > 0 {
+		t.Fatalf("addChallenges failed: %v", errs)
+	}
+
+	build := &BuildMetadata{
+		Seed:          7,
+		Format:        format,
+		Challenge:     "test/finalize-checksums",
+		Schema:        "manual-test",
+		InstanceCount: DYNAMIC_INSTANCES,
+	}
+	if err := mgr.openBuild(build); err != nil {
+		t.Fatalf("openBuild failed: %s", err)
+	}
+
+	const wantChecksum = uint32(0xCAFEBABE)
+	const wantPrev = uint32(0x0BADF00D)
+	build.Flag = "flag{persisted}"
+	build.Checksum = wantChecksum
+	build.PrevChecksum = wantPrev
+	build.Images = []Image{{Host: "challenge"}}
+	if err := mgr.finalizeBuild(build); err != nil {
+		t.Fatalf("finalizeBuild failed: %s", err)
+	}
+
+	got, err := mgr.lookupBuildMetadata(build.Id)
+	if err != nil {
+		t.Fatalf("lookupBuildMetadata failed: %s", err)
+	}
+	if got.Checksum != wantChecksum {
+		t.Errorf("persisted checksum = %#x, want %#x", got.Checksum, wantChecksum)
+	}
+	if got.PrevChecksum != wantPrev {
+		t.Errorf("persisted prevchecksum = %#x, want %#x", got.PrevChecksum, wantPrev)
+	}
+}
+
+// TestOpenBuildStampsChecksum verifies that a freshly opened build already
+// carries its content checksum (derived from the challenge source checksum and
+// flag format), so an in-flight build is visible to contentReferenced before
+// finalizeBuild runs.
+func TestOpenBuildStampsChecksum(t *testing.T) {
+	mgr := setupTestManager(t)
+	defer mgr.db.Close()
+
+	const format = "flag{%s}"
+	const sourceChecksum = uint32(0x0102ABCD)
+	challenge := retentionTestChallenge("test/openbuild-stamp", sourceChecksum)
+	if errs := mgr.addChallenges([]*ChallengeMetadata{challenge}); len(errs) > 0 {
+		t.Fatalf("addChallenges failed: %v", errs)
+	}
+
+	build := &BuildMetadata{
+		Seed:          3,
+		Format:        format,
+		Challenge:     "test/openbuild-stamp",
+		Schema:        "manual-test",
+		InstanceCount: DYNAMIC_INSTANCES,
+	}
+	if err := mgr.openBuild(build); err != nil {
+		t.Fatalf("openBuild failed: %s", err)
+	}
+	if want := contentChecksum(sourceChecksum, format); build.Checksum != want {
+		t.Errorf("openBuild stamped checksum %#x, want %#x", build.Checksum, want)
+	}
+}
+
+// TestContentReferencedFailsSafeOnError verifies the documented safety
+// property: on a query error contentReferenced returns true (keep the images)
+// rather than false (delete them). Closing the database forces the error.
+func TestContentReferencedFailsSafeOnError(t *testing.T) {
+	mgr := setupTestManager(t)
+
+	bMeta := &BuildMetadata{Challenge: "test/whatever", Seed: 1, Format: "flag{%s}", Checksum: 0x1234}
+	mgr.db.Close() // subsequent queries error
+
+	if !mgr.contentReferenced(bMeta, 0) {
+		t.Error("expected contentReferenced to fail safe (true) on a query error")
+	}
+}
+
+// TestContentReferencedIgnoresFormat verifies that two builds sharing
+// (challenge, seed, checksum) but differing in flag format still count as
+// referencing the same images: a docker tag is (challenge, seed, checksum,
+// host), so format must not narrow the key.
+func TestContentReferencedIgnoresFormat(t *testing.T) {
+	mgr := setupTestManager(t)
+	defer mgr.db.Close()
+
+	challenge := retentionTestChallenge("test/format-agnostic", 0x55aa)
+	if errs := mgr.addChallenges([]*ChallengeMetadata{challenge}); len(errs) > 0 {
+		t.Fatalf("addChallenges failed: %v", errs)
+	}
+
+	const seed = 9
+	const checksum = uint32(0xFACEFEED)
+	idA := insertTestBuild(t, mgr, "event-a", "test/format-agnostic", "flag{%s}", seed, checksum)
+	insertTestBuild(t, mgr, "event-b", "test/format-agnostic", "ctf{%s}", seed, checksum)
+
+	// A tag-identity query keyed on challenge+seed+checksum must see the
+	// different-format sibling as a reference.
+	shared := &BuildMetadata{Challenge: "test/format-agnostic", Seed: seed, Format: "flag{%s}", Checksum: checksum}
+	if !mgr.contentReferenced(shared, idA) {
+		t.Error("expected a different-format build with the same checksum to count as a reference")
+	}
+}
+
+// TestMigrateBuildChecksumsResumable verifies that the backfill is data-driven
+// and idempotent: a row left at checksum=0 after the column already exists (as
+// an interrupted migration would leave it) is still backfilled on a later run,
+// rather than being skipped forever by a column-existence guard.
+func TestMigrateBuildChecksumsResumable(t *testing.T) {
+	mgr := setupTestManager(t)
+	defer mgr.db.Close()
+
+	const format = "flag{%s}"
+	const sourceChecksum = uint32(0x99887766)
+	challenge := retentionTestChallenge("test/resumable", sourceChecksum)
+	if errs := mgr.addChallenges([]*ChallengeMetadata{challenge}); len(errs) > 0 {
+		t.Fatalf("addChallenges failed: %v", errs)
+	}
+
+	// A row stranded at checksum=0 despite the column already existing.
+	id := insertTestBuild(t, mgr, "event", "test/resumable", format, 4, 0)
+
+	// The backfill re-runs (m.cli is nil, so retagging is skipped) and must
+	// resolve the stranded row.
+	if err := mgr.migrateBuildChecksums(mgr.db); err != nil {
+		t.Fatalf("migrateBuildChecksums failed: %s", err)
+	}
+
+	var got uint32
+	if err := mgr.db.Get(&got, "SELECT checksum FROM builds WHERE id = ?;", id); err != nil {
+		t.Fatalf("failed to read checksum: %s", err)
+	}
+	if want := contentChecksum(sourceChecksum, format); got != want {
+		t.Errorf("resumed backfill checksum = %#x, want %#x", got, want)
+	}
+
+	// Idempotent: a second pass changes nothing and still succeeds.
+	if err := mgr.migrateBuildChecksums(mgr.db); err != nil {
+		t.Fatalf("second migrateBuildChecksums pass failed: %s", err)
+	}
+}

--- a/cmgr/solver_framework.go
+++ b/cmgr/solver_framework.go
@@ -97,7 +97,17 @@ func (m *Manager) executeSolver(cMeta *ChallengeMetadata, bMeta *BuildMetadata, 
 	solveCtx := m.createSolveContext(cMeta, bMeta)
 
 	imageName := fmt.Sprintf("%s/%s:%d", bMeta.Challenge, "solver", bMeta.Id)
-	opts := client.ImageBuildOptions{Remove: true, Tags: []string{imageName}}
+	opts := client.ImageBuildOptions{
+		Remove: true,
+		Tags:   []string{imageName},
+		// Label solver images like challenge and base images (see executeBuild,
+		// freezeBaseImage) so every image cmgr builds is discoverable by a
+		// future label-based orphan sweep.
+		Labels: map[string]string{
+			"cmgr.managed":   "true",
+			"cmgr.challenge": string(cMeta.Id),
+		},
+	}
 
 	// Build the base image (will run the solver)
 	resp, err := m.cli.ImageBuild(m.ctx, solveCtx, opts)

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -45,16 +45,23 @@ type Manager struct {
 	challengeDockerfiles map[string][]byte
 	rand                 *rand.Rand
 	randMu               sync.Mutex
-	challengeInterface   string
-	challengeRegistry    string
-	authString           string
-	hostOSType           string // docker daemon OSType, cached once at initDocker (immutable for the daemon)
-	portLow              int
-	portHigh             int
-	lastPruneUnix        atomic.Int64 // atomic UnixNano timestamp used as CAS gate for prune interval
-	pruneInterval        time.Duration
-	pruneAge             time.Duration
-	launchSemaphore      chan struct{}
+	// imageMu serializes the "is this content still referenced? if not, untag"
+	// critical sections (executeBuild cleanup, pruneReplacedImages,
+	// destroyImages) so a concurrent remover cannot delete a tag between
+	// another's reference check and its ImageRemove. Content-addressed tags are
+	// shared across build rows, so these checks race under cmgrd's concurrent
+	// request handling.
+	imageMu            sync.Mutex
+	challengeInterface string
+	challengeRegistry  string
+	authString         string
+	hostOSType         string // docker daemon OSType, cached once at initDocker (immutable for the daemon)
+	portLow            int
+	portHigh           int
+	lastPruneUnix      atomic.Int64 // atomic UnixNano timestamp used as CAS gate for prune interval
+	pruneInterval      time.Duration
+	pruneAge           time.Duration
+	launchSemaphore    chan struct{}
 }
 
 type PortInfo struct {
@@ -193,13 +200,13 @@ type BuildMetadata struct {
 	// contentChecksum). It is set when the images are built, so after a source
 	// change it intentionally differs from the value derived from the
 	// challenge's current metadata until the build is rebuilt.
-	Checksum uint32 `json:"checksum"`
+	Checksum uint32 `json:"checksum,omitempty"`
 	// PrevChecksum is the generation Checksum displaced on the last rebuild
 	// (0 = none): its images are retained as the rollback target. A future
 	// `rollback` operation would swap it with Checksum, re-extract /challenge
 	// from that image (see executeBuild's extraction step), and restart
 	// instances. Same-row rollback is format- and seed-stable by construction.
-	PrevChecksum uint32              `json:"prev_checksum" db:"prevchecksum"`
+	PrevChecksum uint32              `json:"prev_checksum,omitempty" db:"prevchecksum"`
 	Images       []Image             `json:"images"`
 	HasArtifacts bool                `json:"has_artifacts"`
 	LastSolved   int64               `json:"last_solved"`

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -111,7 +111,7 @@ type ChallengeMetadata struct {
 	Attributes       map[string]string   `json:"attributes,omitempty"`
 	ChallengeOptions ChallengeOptions    `json:"challenge_options,omitempty"`
 
-	SolveScript bool             `json:"solve_script,omitempty"`
+	SolveScript bool `json:"solve_script,omitempty"`
 
 	// DeliveryType classifies what a player receives and therefore what cmgr
 	// must stand up at runtime. It is derived (deriveDeliveryType), never stored
@@ -169,6 +169,7 @@ func deriveDeliveryType(challengeType string, publishedPorts int) DeliveryType {
 func (cm *ChallengeMetadata) NeedsInstance() bool {
 	return cm.DeliveryType == "" || cm.DeliveryType == DeliveryService
 }
+
 type ChallengeUpdates struct {
 	Added      []*ChallengeMetadata `json:"added"`
 	Refreshed  []*ChallengeMetadata `json:"refreshed"`
@@ -185,8 +186,14 @@ type BuildMetadata struct {
 	Flag       string            `json:"flag"`
 	LookupData map[string]string `json:"lookup_data,omitempty"`
 
-	Seed         int                 `json:"seed"`
-	Format       string              `json:"format"`
+	Seed   int    `json:"seed"`
+	Format string `json:"format"`
+	// Checksum identifies the content this build's images were produced from:
+	// a CRC-32 over the challenge's source checksum and the flag format (see
+	// contentChecksum). It is set when the images are built, so after a source
+	// change it intentionally differs from the value derived from the
+	// challenge's current metadata until the build is rebuilt.
+	Checksum     uint32              `json:"checksum"`
 	Images       []Image             `json:"images"`
 	HasArtifacts bool                `json:"has_artifacts"`
 	LastSolved   int64               `json:"last_solved"`

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -193,7 +193,13 @@ type BuildMetadata struct {
 	// contentChecksum). It is set when the images are built, so after a source
 	// change it intentionally differs from the value derived from the
 	// challenge's current metadata until the build is rebuilt.
-	Checksum     uint32              `json:"checksum"`
+	Checksum uint32 `json:"checksum"`
+	// PrevChecksum is the generation Checksum displaced on the last rebuild
+	// (0 = none): its images are retained as the rollback target. A future
+	// `rollback` operation would swap it with Checksum, re-extract /challenge
+	// from that image (see executeBuild's extraction step), and restart
+	// instances. Same-row rollback is format- and seed-stable by construction.
+	PrevChecksum uint32              `json:"prev_checksum" db:"prevchecksum"`
 	Images       []Image             `json:"images"`
 	HasArtifacts bool                `json:"has_artifacts"`
 	LastSolved   int64               `json:"last_solved"`


### PR DESCRIPTION
## What & why
Docker image tags currently embed the local build id (`{challenge}:{id}-{host}`), a sqlite rowid that means nothing across cmgr instances and gets mutated in place on every rebuild. This switches tags to content identity — `{challenge}:s{seed}-{checksum}-{host}` — so the same challenge content resolves to the same tag on any host, and a source change produces a *new* tag instead of silently repointing the old one. This is the groundwork for pushing challenge images to a registry.

## Key changes
- **Content-addressed tags:** `checksum = CRC-32(source checksum + flag format)`; seed carried explicitly in the tag (`s` prefix keeps negative seeds valid). Build id no longer appears in any tag.
- **`builds.checksum` + `builds.prevchecksum` columns.** `prevchecksum` retains the generation displaced by the last rebuild as a rollback target (the `rollback` verb itself is not implemented — just the retained state + pointers).
- **`cmgr update --prune-old`** (default **off**): untags the generation each rebuild displaces from retention. Off by default because another cmgr on the same daemon may share a content tag, which this database can't see. Removal everywhere is refcount-guarded and best-effort.
- **Image labels** (`cmgr.managed`, `cmgr.challenge`) for future orphan discovery.
- Schema-converge now **warns on stale/drifted source** instead of silently returning.

## Migration & compatibility
- On first start the `builds.checksum` backfill runs and retags existing local images from the legacy form. It is **resumable** (data-driven, idempotent) so an interrupted upgrade retries rather than stranding builds.
- New JSON fields `checksum`/`prev_checksum` on `BuildMetadata` are additive (`omitempty`, documented in swagger).
- ⚠️ External tooling that reconstructs image names from build ids will break — tag format changed.

## Testing
Unit suite green (incl. new tests for the retention predicates, checksum persistence/stamping, refcount fail-safe, and migration resumability). Full build → tag/label → prune → destroy lifecycle verified live against Docker.
